### PR TITLE
feat: Badge 구현

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,34 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { IcGroundLine } from '@/style';
+
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Atoms/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+};
+export default meta;
+
+const BadgeStory = ({ ...badgeProps }) => {
+  return <Badge {...badgeProps} />;
+};
+
+type Story = StoryObj<typeof Badge>;
+export const withIcon: Story = {
+  args: {
+    children: 'Badge',
+    leftIcon: <IcGroundLine />,
+  },
+  render: BadgeStory,
+};
+
+export const withoutIcon: Story = {
+  args: {
+    children: 'Badge',
+  },
+  render: BadgeStory,
+};

--- a/src/components/Badge/Badge.style.ts
+++ b/src/components/Badge/Badge.style.ts
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 
-import { SemanticColor } from '../..';
+import { SemanticColor } from '@/style';
 
 interface StyledBadgeProps {
   backgroundColor: SemanticColor;

--- a/src/components/Badge/Badge.style.ts
+++ b/src/components/Badge/Badge.style.ts
@@ -1,0 +1,19 @@
+import { styled } from 'styled-components';
+
+import { SemanticColor } from '../..';
+
+interface StyledBadgeProps {
+  backgroundColor: SemanticColor;
+}
+export const StyledBadge = styled.div<StyledBadgeProps>`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  width: fit-content;
+  height: 24px;
+  padding: 0 var(--padding);
+  border-radius: 2px;
+  background-color: ${({ theme, backgroundColor }) => theme.color[backgroundColor]};
+
+  ${({ theme }) => theme.typo.caption1};
+`;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,42 @@
+import { IconContext, SemanticColor } from '../..';
+
+import { StyledBadge } from './Badge.style';
+import { BadgeProps, BadgeColor } from './Badge.type';
+
+const backgroundColorMap: { [key in BadgeColor]: SemanticColor } = {
+  [BadgeColor.Mono]: 'monoItemBG',
+  [BadgeColor.Lime]: 'limeItemBG',
+  [BadgeColor.Green]: 'greenItemBG',
+  [BadgeColor.Emerald]: 'emeraldItemBG',
+  [BadgeColor.Aqua]: 'aquaItemBG',
+  [BadgeColor.Blue]: 'blueItemBG',
+  [BadgeColor.Indigo]: 'indigoItemBG',
+  [BadgeColor.Violet]: 'violetItemBG',
+  [BadgeColor.Purple]: 'purpleItemBG',
+  [BadgeColor.Pink]: 'pinkItemBG',
+} as const;
+
+function Badge({ color = BadgeColor.Mono, children = 'Badge', leftIcon }: BadgeProps) {
+  return (
+    <StyledBadge
+      style={{
+        padding: leftIcon ? '0 8px' : '0 12px',
+      }}
+      backgroundColor={backgroundColorMap[color]}
+    >
+      {leftIcon && (
+        <IconContext.Provider
+          value={{
+            color: '#0f0f0f',
+            size: '1rem',
+          }}
+        >
+          {leftIcon}
+        </IconContext.Provider>
+      )}
+      {children}
+    </StyledBadge>
+  );
+}
+
+export { Badge };

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,28 +1,15 @@
-import { IconContext, SemanticColor } from '../..';
+import { IconContext } from '../..';
 
 import { StyledBadge } from './Badge.style';
-import { BadgeProps, BadgeColor } from './Badge.type';
+import { BadgeProps } from './Badge.type';
 
-const backgroundColorMap: { [key in BadgeColor]: SemanticColor } = {
-  [BadgeColor.Mono]: 'monoItemBG',
-  [BadgeColor.Lime]: 'limeItemBG',
-  [BadgeColor.Green]: 'greenItemBG',
-  [BadgeColor.Emerald]: 'emeraldItemBG',
-  [BadgeColor.Aqua]: 'aquaItemBG',
-  [BadgeColor.Blue]: 'blueItemBG',
-  [BadgeColor.Indigo]: 'indigoItemBG',
-  [BadgeColor.Violet]: 'violetItemBG',
-  [BadgeColor.Purple]: 'purpleItemBG',
-  [BadgeColor.Pink]: 'pinkItemBG',
-} as const;
-
-function Badge({ color = BadgeColor.Mono, children = 'Badge', leftIcon }: BadgeProps) {
+function Badge({ color = 'monoItemBG', children = 'Badge', leftIcon }: BadgeProps) {
   return (
     <StyledBadge
       style={{
         padding: leftIcon ? '0 8px' : '0 12px',
       }}
-      backgroundColor={backgroundColorMap[color]}
+      backgroundColor={color}
     >
       {leftIcon && (
         <IconContext.Provider

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import { IconContext } from '../..';
+import { IconContext } from '@/style';
 
 import { StyledBadge } from './Badge.style';
 import { BadgeProps } from './Badge.type';

--- a/src/components/Badge/Badge.type.ts
+++ b/src/components/Badge/Badge.type.ts
@@ -1,18 +1,7 @@
-export enum BadgeColor {
-  Mono = 'mono',
-  Lime = 'lime',
-  Green = 'green',
-  Emerald = 'emerald',
-  Aqua = 'aqua',
-  Blue = 'blue',
-  Indigo = 'indigo',
-  Violet = 'violet',
-  Purple = 'purple',
-  Pink = 'pink',
-}
+import { SemanticBGColor } from '@/style';
 
 export interface BadgeProps {
-  color?: BadgeColor;
+  color?: SemanticBGColor;
   children?: React.ReactNode;
   leftIcon?: React.ReactNode;
 }

--- a/src/components/Badge/Badge.type.ts
+++ b/src/components/Badge/Badge.type.ts
@@ -1,0 +1,18 @@
+export enum BadgeColor {
+  Mono = 'mono',
+  Lime = 'lime',
+  Green = 'green',
+  Emerald = 'emerald',
+  Aqua = 'aqua',
+  Blue = 'blue',
+  Indigo = 'indigo',
+  Violet = 'violet',
+  Purple = 'purple',
+  Pink = 'pink',
+}
+
+export interface BadgeProps {
+  color?: BadgeColor;
+  children?: string;
+  leftIcon?: React.ReactNode;
+}

--- a/src/components/Badge/Badge.type.ts
+++ b/src/components/Badge/Badge.type.ts
@@ -13,6 +13,6 @@ export enum BadgeColor {
 
 export interface BadgeProps {
   color?: BadgeColor;
-  children?: string;
+  children?: React.ReactNode;
   leftIcon?: React.ReactNode;
 }

--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from './Badge';
+export type { BadgeProps } from './Badge.type';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
* 신나는 Badge 구현하기

## 2️⃣ 알아두시면 좋아요!

<details>
  <summary>SemanticBGColor 타입 생기기 이전에 적었던 내용 (지금은 안 봐도 되는 내용)</summary>

* Badge.type에 `BadgeColor`를 만들고, Badge.tsx에서 `backgroundColorMap` 로 매핑해서 쓴 이유:
  
  `BadgeProps` - `color`를 `SemanticItemColor` 타입으로 설정하면 스토리북 옵션에 `--Primary`, `--Text` 까지 포함되어서, `--BG` 만 넣은 `backgroundColorMap`을 만들어서 작업했습니다 🤔 왠지 이거 뭐야!??!?! 하실까봐.. 미리 변명을 좀

![semanticItemColor](https://github.com/yourssu/YDS-React/assets/87255462/9c2a78e8-1b28-42aa-ace2-f5a7084fa09e)
</details>


## 3️⃣ 추후 작업
- pr 리뷰 달린 내용 기반으로 수정 ➡ https://github.com/yourssu/YDS-React/pull/6/commits/3b010a7532903ac92252ad876e8f5c507466c6cf
- #7 머지 이후 `color` 타입 수정 ➡ https://github.com/yourssu/YDS-React/pull/6/commits/42a58025263df17285ddcabe98cb5f8bed8ec711