### PR TITLE
feat: SemanticBGColor 추가

### DIFF
--- a/src/style/foundation/color/semanticColor/semanticColor.type.ts
+++ b/src/style/foundation/color/semanticColor/semanticColor.type.ts
@@ -93,3 +93,7 @@ export type SemanticColor =
   | SemanticPickerColor
   | SemanticShadowColor
   | SemanticItemColor;
+
+// Utility Types
+type OnlyBGColor<T> = T extends `${string}BG` ? T : never;
+export type SemanticBGColor = OnlyBGColor<SemanticColor>;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
https://github.com/yourssu/YDS-React/pull/6#issuecomment-1724679856

### 기존 코드에 영향을 미치지 않는 변경사항
`SemanticBGColor` 타입을 추가했어요.

## 2️⃣ 알아두시면 좋아요!
`SemanticBGColor` 타입은 기존 타입에서 자주 사용할 것 같은 타입을 분리하기 위한 유틸리티 타입이에요. 별도의 색상 파레트를 가지는 것이 아닌 `*BG` 형태의 색상만 별도로 분리했어요.

## 3️⃣ 추후 작업

