### PR TITLE
feat: PlainButton 구현

### DIFF
--- a/src/components/PlainButton/PlainButton.stories.tsx
+++ b/src/components/PlainButton/PlainButton.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { IcGroundLine } from '@/style';
+
+import { PlainButton } from './PlainButton';
+
+const meta: Meta<typeof PlainButton> = {
+  title: 'Component/PlainButton',
+  component: PlainButton,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlainButton>;
+
+export const Primary: Story = {
+  args: {
+    children: 'Primary/Small',
+    size: 'small',
+    isPointed: false,
+    isWarned: false,
+  },
+};
+
+export const Pointed: Story = {
+  args: {
+    children: 'Pointed/Medium',
+    size: 'medium',
+    isPointed: true,
+    isWarned: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled/Medium',
+    size: 'medium',
+    disabled: true,
+    isPointed: false,
+    isWarned: false,
+    leftIcon: <IcGroundLine />,
+  },
+};
+
+export const Warned: Story = {
+  args: {
+    children: 'Warned/Large',
+    size: 'large',
+    isPointed: false,
+    isWarned: true,
+    rightIcon: <IcGroundLine />,
+  },
+};

--- a/src/components/PlainButton/PlainButton.style.ts
+++ b/src/components/PlainButton/PlainButton.style.ts
@@ -1,0 +1,86 @@
+import { css, styled } from 'styled-components';
+
+import { typos } from '@/style';
+
+import { PlainButtonProps, PlainButtonSize } from './PlainButton.type';
+
+interface StyledPlainButtonProps {
+  $size: PlainButtonSize;
+  $isPointed: PlainButtonProps['isPointed'];
+  $isWarned: PlainButtonProps['isWarned'];
+}
+
+const getSizeStyle = ($size: PlainButtonSize) => {
+  switch ($size) {
+    case 'large':
+      return css`
+        height: 24px;
+        .icon {
+          width: 24px;
+          height: 24px;
+        }
+      `;
+    case 'medium':
+      return css`
+        height: 20px;
+        font-size: 14px;
+        ${typos.button3}
+        .icon {
+          width: 20px;
+          height: 20px;
+        }
+      `;
+    case 'small':
+      return css`
+        height: 16px;
+        font-size: 12px;
+        ${typos.button4}
+        .icon {
+          width: 16px;
+          height: 16px;
+        }
+      `;
+  }
+};
+
+const getStyle = ($isPointed: boolean, $isWarned: boolean) => {
+  if ($isWarned) {
+    return css`
+      color: ${(props) => props.theme.color.buttonWarned};
+      &:hover {
+        cursor: pointer;
+        color: ${(props) => props.theme.color.buttonWarnedPressed};
+      }
+    `;
+  } else if ($isPointed) {
+    return css`
+      color: ${(props) => props.theme.color.buttonPoint};
+      &:hover {
+        cursor: pointer;
+        color: ${(props) => props.theme.color.buttonPointPressed};
+      }
+    `;
+  } else
+    return css`
+      color: ${(props) => props.theme.color.buttonNormal};
+      &:hover {
+        cursor: pointer;
+        color: ${(props) => props.theme.color.buttonNormalPressed};
+      }
+    `;
+};
+
+export const StyledPlainButton = styled.button<StyledPlainButtonProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+  border: none;
+  gap: 2px;
+  ${({ $size }) => getSizeStyle($size)}
+  ${({ $isPointed, $isWarned }) => getStyle($isPointed, $isWarned)}
+  &:disabled {
+    color: ${({ theme }) => theme.color.buttonDisabled};
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/PlainButton/PlainButton.tsx
+++ b/src/components/PlainButton/PlainButton.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from 'react';
+
+import { IconContext } from '@/style';
+
+import { StyledPlainButton } from './PlainButton.style';
+
+import { PlainButtonProps } from '.';
+
+export const PlainButton = forwardRef<HTMLButtonElement, PlainButtonProps>(
+  ({ leftIcon, children, rightIcon, ...props }, ref) => {
+    return (
+      <StyledPlainButton
+        ref={ref}
+        disabled={props.disabled}
+        $size={props.size}
+        $isPointed={props.isPointed}
+        $isWarned={props.isWarned}
+        {...props}
+      >
+        <IconContext.Provider
+          value={{
+            color: 'currentColor',
+          }}
+        >
+          <div className="icon left-icon">{leftIcon}</div>
+        </IconContext.Provider>
+        {props.size !== 'large' && <span className="plainButton-child">{children}</span>}
+        {!leftIcon && (
+          <IconContext.Provider
+            value={{
+              color: 'currentColor',
+            }}
+          >
+            <div className="icon right-icon">{rightIcon}</div>
+          </IconContext.Provider>
+        )}
+      </StyledPlainButton>
+    );
+  }
+);

--- a/src/components/PlainButton/PlainButton.type.ts
+++ b/src/components/PlainButton/PlainButton.type.ts
@@ -1,0 +1,10 @@
+export type PlainButtonSize = 'small' | 'medium' | 'large';
+
+export interface PlainButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size: PlainButtonSize;
+  isPointed: boolean;
+  isWarned: boolean;
+  leftIcon?: React.ReactNode;
+  children?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+}

--- a/src/components/PlainButton/index.ts
+++ b/src/components/PlainButton/index.ts
@@ -1,0 +1,2 @@
+export { PlainButton } from './PlainButton';
+export type { PlainButtonProps } from './PlainButton.type';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,6 @@ export type { YDSWrapperProps } from './YDSWrapper';
 
 export { BoxButton } from './BoxButton';
 export type { BoxButtonProps } from './BoxButton';
+
+export { PlainButton } from './PlainButton';
+export type { PlainButtonProps } from './PlainButton';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
- PlainButton 구현했습니다.

## 2️⃣ 알아두시면 좋아요!
- PlainButton Icon 규칙에 있어 노션 문서와 피그마가 일치하지 않는 상태입니다.
- 노션 문서에 따르면 PlainButton의 경우 leftIcon과 rightIcon을 동시에 사용할 수 없으며, 우선순위는 leftIcon에 있다고 기록되어 있습니다.
- 반면, 피그마에서는 둘 다 사용하고 있어서 현재 슬랙에 질문 드린 상태입니다.
- 개발은 우선 노션 문서를 따라 구현했어요!
슬랙: https://yourssu.slack.com/archives/C01U696R2JJ/p1696406332824389?thread_ts=1695554153.985089&cid=C01U696R2JJ
노션: https://www.notion.so/yourssu/PlainButton-46dd9c009be74e5bbecf22f7679ad050
피그마: 
![image](https://github.com/yourssu/YDS-React/assets/84809236/68a1f1a2-febe-441b-b8e7-b3426a23dfd5)
- 추가로, large size의 경우 글씨가 보이지 않도록 하였으며 Disabled > Warned > Pointed 우선순위를 따릅니다.
- 모두 노션 문서를 따라 개발한 점 참고해주세요!