### PR TITLE
fix: Badge 관련 story, type 이름 수정

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -18,7 +18,7 @@ const BadgeStory = ({ ...badgeProps }) => {
 };
 
 type Story = StoryObj<typeof Badge>;
-export const withIcon: Story = {
+export const WithIcon: Story = {
   args: {
     children: 'Badge',
     leftIcon: <IcGroundLine />,
@@ -26,7 +26,7 @@ export const withIcon: Story = {
   render: BadgeStory,
 };
 
-export const withoutIcon: Story = {
+export const WithoutIcon: Story = {
   args: {
     children: 'Badge',
   },

--- a/src/components/Badge/Badge.style.ts
+++ b/src/components/Badge/Badge.style.ts
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 import { SemanticColor } from '@/style';
 
 interface StyledBadgeProps {
-  backgroundColor: SemanticColor;
+  $backgroundColor: SemanticColor;
 }
 export const StyledBadge = styled.div<StyledBadgeProps>`
   display: flex;
@@ -13,7 +13,7 @@ export const StyledBadge = styled.div<StyledBadgeProps>`
   height: 24px;
   padding: 0 var(--padding);
   border-radius: 2px;
-  background-color: ${({ theme, backgroundColor }) => theme.color[backgroundColor]};
+  background-color: ${({ theme, $backgroundColor }) => theme.color[$backgroundColor]};
 
   ${({ theme }) => theme.typo.caption1};
 `;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -9,7 +9,7 @@ function Badge({ color = 'monoItemBG', children = 'Badge', leftIcon }: BadgeProp
       style={{
         padding: leftIcon ? '0 8px' : '0 12px',
       }}
-      backgroundColor={color}
+      $backgroundColor={color}
     >
       {leftIcon && (
         <IconContext.Provider


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
### 기존 코드에 영향을 미치지 않는 변경사항
- `StyledBadgeProps` 타입의 속성 앞에 `$`를 붙였습니다 ([관련 노션](https://www.notion.so/yourssu/styled-components-Prop-3188e9ac14f64c608065662998b898ab?pvs=4))
- Badge 관련 스토리 이름을 파스칼 케이스로 수정했습니다


