### PR TITLE
feat: ListItem 구현

### DIFF
--- a/src/components/BoxButton/BoxButton.style.ts
+++ b/src/components/BoxButton/BoxButton.style.ts
@@ -1,7 +1,5 @@
 import { css, styled } from 'styled-components';
 
-import { typos } from '@/style';
-
 import {
   BoxButtonProps,
   BoxButtonRounding,
@@ -117,22 +115,22 @@ const getSizeStyle = ($size: BoxButtonSize) => {
     case 'extraLarge':
       return css`
         height: 56px;
-        ${typos.button1}
+        ${({ theme }) => theme.typo.button1}
       `;
     case 'large':
       return css`
         height: 48px;
-        ${typos.button2}
+        ${({ theme }) => theme.typo.button2}
       `;
     case 'medium':
       return css`
         height: 40px;
-        ${typos.button2}
+        ${({ theme }) => theme.typo.button2}
       `;
     case 'small':
       return css`
         height: 32px;
-        ${typos.button4}
+        ${({ theme }) => theme.typo.button4}
       `;
   }
 };

--- a/src/components/BoxButton/BoxButton.style.ts
+++ b/src/components/BoxButton/BoxButton.style.ts
@@ -150,6 +150,7 @@ export const StyledBoxButton = styled.button<StyledBoxButtonProps>`
   ${({ $isWarned, $variant }) => $isWarned && getWarnedStyle($variant)}
   &:disabled {
     ${({ $variant }) => getDisabledStyle($variant)}
+    cursor: not-allowed;
   }
   & > .boxButton-child {
     display: block;

--- a/src/components/CheckBox/CheckBox.style.ts
+++ b/src/components/CheckBox/CheckBox.style.ts
@@ -1,7 +1,5 @@
 import { css, styled } from 'styled-components';
 
-import { typos } from '@/style';
-
 import { CheckBoxProps, CheckBoxSize } from './CheckBox.type';
 
 interface StyledCheckBoxProps {
@@ -47,7 +45,7 @@ export const StyledCheckBoxWrapper = styled.div<StyledCheckBoxProps>`
   align-items: center;
   justify-content: center;
   user-select: none;
-  ${typos.button3}
+  ${({ theme }) => theme.typo.button3}
 
   cursor: pointer;
   label {
@@ -67,7 +65,7 @@ export const StyledCheckBoxWrapper = styled.div<StyledCheckBoxProps>`
     $isDisabled &&
     $size === 'small' &&
     css`
-      ${typos.button4}
+      ${({ theme }) => theme.typo.button4}
     `}
 
   ${({ $isSelected, $isDisabled, theme }) =>

--- a/src/components/ListItem/ListItem.stories.tsx
+++ b/src/components/ListItem/ListItem.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { IcGroundLine } from '@/style';
+
+import { ListItem } from './ListItem';
+
+const meta: Meta<typeof ListItem> = {
+  title: 'Atoms/ListItem',
+  component: ListItem,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ListItem>;
+
+export const Primary: Story = {
+  args: {
+    children: 'Primary',
+    isPressed: false,
+  },
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    children: 'WithLeftIcon',
+    isPressed: false,
+    leftIcon: <IcGroundLine />,
+  },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    children: 'WithRightIcon',
+    isPressed: true,
+    width: '400px',
+    rightIcon: <IcGroundLine />,
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    children: 'WithIcon',
+    width: '400px',
+    isPressed: true,
+    leftIcon: <IcGroundLine />,
+    rightIcon: <IcGroundLine />,
+  },
+};

--- a/src/components/ListItem/ListItem.style.ts
+++ b/src/components/ListItem/ListItem.style.ts
@@ -1,7 +1,5 @@
 import { styled } from 'styled-components';
 
-import { typos } from '@/style';
-
 import { ListItemProps } from './ListItem.type';
 
 interface StyledListItemProps {
@@ -25,7 +23,7 @@ export const StyledListItem = styled.li<StyledListItemProps>`
   .right-icon {
     margin-left: auto;
   }
-  ${typos.body1}
+  ${({ theme }) => theme.typo.body1}
   color: ${({ theme }) => theme.color.textSecondary};
   background-color: ${({ $isPressed, theme }) =>
     $isPressed ? theme.color.bgPressed : 'transparent'};

--- a/src/components/ListItem/ListItem.style.ts
+++ b/src/components/ListItem/ListItem.style.ts
@@ -1,0 +1,36 @@
+import { styled } from 'styled-components';
+
+import { typos } from '@/style';
+
+import { ListItemProps } from './ListItem.type';
+
+interface StyledListItemProps {
+  $isPressed: ListItemProps['isPressed'];
+  $width: ListItemProps['width'];
+}
+
+export const StyledListItem = styled.li<StyledListItemProps>`
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  gap: 8px;
+  width: ${({ $width }) => $width};
+  height: 100%;
+  min-height: 48px;
+  font-size: 15px;
+  .icon {
+    width: 24px;
+    height: 24px;
+  }
+  .right-icon {
+    margin-left: auto;
+  }
+  ${typos.body1}
+  color: ${({ theme }) => theme.color.textSecondary};
+  background-color: ${({ $isPressed, theme }) =>
+    $isPressed ? theme.color.bgPressed : 'transparent'};
+  cursor: pointer;
+  &:hover {
+    background-color: ${({ theme }) => theme.color.bgPressed};
+  }
+`;

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -1,0 +1,22 @@
+import { IconContext } from '@/style';
+
+import { StyledListItem } from './ListItem.style';
+import { ListItemProps } from './ListItem.type';
+
+export const ListItem = ({ isPressed, leftIcon, rightIcon, children, ...props }: ListItemProps) => {
+  return (
+    <StyledListItem $isPressed={isPressed} $width={props.width} {...props}>
+      {leftIcon && (
+        <IconContext.Provider value={{ color: 'currentColor' }}>
+          <div className="icon left-icon">{leftIcon}</div>
+        </IconContext.Provider>
+      )}
+      <span className="listItem-child">{children}</span>
+      {rightIcon && (
+        <IconContext.Provider value={{ color: 'currentColor' }}>
+          <div className="icon right-icon">{rightIcon}</div>
+        </IconContext.Provider>
+      )}
+    </StyledListItem>
+  );
+};

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -1,22 +1,27 @@
+import { forwardRef } from 'react';
+
 import { IconContext } from '@/style';
 
 import { StyledListItem } from './ListItem.style';
 import { ListItemProps } from './ListItem.type';
 
-export const ListItem = ({ isPressed, leftIcon, rightIcon, children, ...props }: ListItemProps) => {
-  return (
-    <StyledListItem $isPressed={isPressed} $width={props.width} {...props}>
-      {leftIcon && (
-        <IconContext.Provider value={{ color: 'currentColor' }}>
-          <div className="icon left-icon">{leftIcon}</div>
-        </IconContext.Provider>
-      )}
-      <span className="listItem-child">{children}</span>
-      {rightIcon && (
-        <IconContext.Provider value={{ color: 'currentColor' }}>
-          <div className="icon right-icon">{rightIcon}</div>
-        </IconContext.Provider>
-      )}
-    </StyledListItem>
-  );
-};
+export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
+  ({ isPressed, leftIcon, rightIcon, children, ...props }, ref) => {
+    return (
+      <StyledListItem ref={ref} $isPressed={isPressed} $width={props.width} {...props}>
+        {leftIcon && (
+          <IconContext.Provider value={{ color: 'currentColor' }}>
+            <div className="icon left-icon">{leftIcon}</div>
+          </IconContext.Provider>
+        )}
+        <span className="listItem-child">{children}</span>
+        {rightIcon && (
+          <IconContext.Provider value={{ color: 'currentColor' }}>
+            <div className="icon right-icon">{rightIcon}</div>
+          </IconContext.Provider>
+        )}
+      </StyledListItem>
+    );
+  }
+);
+ListItem.displayName = 'ListItem';

--- a/src/components/ListItem/ListItem.type.ts
+++ b/src/components/ListItem/ListItem.type.ts
@@ -1,0 +1,7 @@
+export interface ListItemProps {
+  isPressed?: boolean;
+  width?: string | number;
+  children?: React.ReactNode;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+}

--- a/src/components/ListItem/ListItem.type.ts
+++ b/src/components/ListItem/ListItem.type.ts
@@ -1,4 +1,4 @@
-export interface ListItemProps {
+export interface ListItemProps extends React.HTMLAttributes<HTMLLIElement> {
   isPressed?: boolean;
   width?: string | number;
   children?: React.ReactNode;

--- a/src/components/ListItem/index.ts
+++ b/src/components/ListItem/index.ts
@@ -1,0 +1,2 @@
+export { ListItem } from './ListItem';
+export type { ListItemProps } from './ListItem.type';

--- a/src/components/PlainButton/PlainButton.style.ts
+++ b/src/components/PlainButton/PlainButton.style.ts
@@ -1,7 +1,5 @@
 import { css, styled } from 'styled-components';
 
-import { typos } from '@/style';
-
 import { PlainButtonProps, PlainButtonSize } from './PlainButton.type';
 
 interface StyledPlainButtonProps {
@@ -24,7 +22,7 @@ const getSizeStyle = ($size: PlainButtonSize) => {
       return css`
         height: 20px;
         font-size: 14px;
-        ${typos.button3}
+        ${({ theme }) => theme.typo.button3}
         .icon {
           width: 20px;
           height: 20px;
@@ -34,7 +32,7 @@ const getSizeStyle = ($size: PlainButtonSize) => {
       return css`
         height: 16px;
         font-size: 12px;
-        ${typos.button4}
+        ${({ theme }) => theme.typo.button4}
         .icon {
           width: 16px;
           height: 16px;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,3 +18,6 @@ export type { PlainButtonProps } from './PlainButton';
 
 export { Toggle } from './Toggle';
 export type { ToggleProps } from './Toggle';
+
+export { ListItem } from './ListItem';
+export type { ListItemProps } from './ListItem';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
ListItem 구현

## 2️⃣ 알아두시면 좋아요!
- width를 따로 받을 수 있도록 구현했습니다.

- 처음에 ListItem.tsx에서 isPressed를 props.isPressed로 사용했더니 이런 경고가 뜨더라구요
참고하시면 좋을 것 같아서 같이 올려요!
> react does not recognize the `ispressed` prop on a dom element. if you intentionally want it to appear in the dom as a custom attribute, spell it as lowercase `ispressed` instead. if you accidentally passed it from a parent component, remove it from the dom element.

참고: https://legacy.reactjs.org/warnings/unknown-prop.html

- 이전 YDS에서는 ListItem을 Wrapper와 item으로 구성한 후 Wrapper는 ul, item은 li를 확장하도록 개발, List는 Div를 확장하도록 개발한 걸 확인했습니다.
- 저는 ListItem은 li를 확장하도록 개발, List는 ul을 확장하도록 개발하려 하는데 혹시 더 좋은 방법이 있다면 말씀해주시면 좋을 것 같아요!
- 추가로, BoxButton에서 Disabled 시에도 cursor가 작동하길래 수정 코드 여기서 같이 추가했습니다!

## 3️⃣ 추후 작업
ListToggleItem 구현
머지 후 노션에 ListItem 문서 작성

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?

이전 PR 머지되면 다시 받아올게요!
