### PR TITLE
fix: BadgeProps 타입이 HTMLAttribute 확장하도록 수정

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -3,13 +3,14 @@ import { IconContext } from '@/style';
 import { StyledBadge } from './Badge.style';
 import { BadgeProps } from './Badge.type';
 
-const Badge = ({ color = 'monoItemBG', children = 'Badge', leftIcon }: BadgeProps) => {
+const Badge = ({ color = 'monoItemBG', children = 'Badge', leftIcon, ...props }: BadgeProps) => {
   return (
     <StyledBadge
       style={{
         padding: leftIcon ? '0 8px' : '0 12px',
       }}
       $backgroundColor={color}
+      {...props}
     >
       {leftIcon && (
         <IconContext.Provider

--- a/src/components/Badge/Badge.type.ts
+++ b/src/components/Badge/Badge.type.ts
@@ -1,6 +1,6 @@
 import { SemanticBGColor } from '@/style';
 
-export interface BadgeProps {
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
   color?: SemanticBGColor;
   children?: React.ReactNode;
   leftIcon?: React.ReactNode;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- `BadgeProps`가 `React.HTMLAttributes<HTMLDivElement>`를 확장하도록 수정했어요 ~왜 안했을가요~
- StyledBadge(div)에 나머지 props를 넣어줬어요

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
