### PR TITLE
fix: tsc error in Toast.stories.tsx

### DIFF
--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof Toast> = {
           </ol>
           <br />
           <Title>useToast</Title>
-          <span>'Toast 컴포넌트를 사용하기 위한 Custom Hook입니다.'</span>
+          <span>Toast 컴포넌트를 사용하기 위한 Custom Hook입니다.</span>
           <Markdown>{HookSource}</Markdown>
           <br />
           <Stories />

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,11 +1,4 @@
-import {
-  Stories,
-  Primary as PrimaryBlock,
-  Controls,
-  Title,
-  Description,
-  Markdown,
-} from '@storybook/blocks';
+import { Stories, Primary as PrimaryBlock, Controls, Title, Markdown } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
 
 import { useToast } from '@/hooks/useToast';
@@ -35,7 +28,7 @@ const meta: Meta<typeof Toast> = {
           </ol>
           <br />
           <Title>useToast</Title>
-          <Description>Toast 컴포넌트를 사용하기 위한 Custom Hook입니다.</Description>
+          <span>'Toast 컴포넌트를 사용하기 위한 Custom Hook입니다.'</span>
           <Markdown>{HookSource}</Markdown>
           <br />
           <Stories />


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #55 

### 버그 픽스

Description을 사용하려면 of를 통해 참조 or JSDoc을 사용해야 하는 방법으로 변경되었습니다.
반드시 Description을 사용해야 하는 부분은 아니라고 판단하여, span으로 변경했습니다.
|변경 전, Description|변경 후, span|
|--|--|
|<img width="339" alt="image" src="https://github.com/yourssu/YDS-React/assets/84809236/61108ab5-2acf-491e-b8ab-818c9d418e1d">|<img width="407" alt="image" src="https://github.com/yourssu/YDS-React/assets/84809236/667ac9f1-2043-44ca-9bbe-165c04fbeee3">|

## 2️⃣ 알아두시면 좋아요!

#54 에서 build 시 해당 문제로 인해 tsc error가 터지는 상황입니다.
54 PR에서 브랜치를 파서 작업하였고, 54 머지 후 순차 머지하겠습니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
