### PR TITLE
fix: icon.stories.tsx 내 Icon.displayName이 보이지 않는 문제

### DIFF
--- a/iconsAsset/convert.mjs
+++ b/iconsAsset/convert.mjs
@@ -12,7 +12,7 @@ const __dirname = path.resolve();
 const ICONS_DIR = path.join(__dirname, './iconsAsset/static');
 const ICONS_COMPONENTS_DIR = path.join(__dirname, './src/style/foundation/icons/generated');
 const ICONS_INDEX_PATH = path.join(__dirname, './src/style/foundation/icons/generated/index.ts');
-const ICONS_STORIES_PATH = path.join(__dirname, './src/style/foundation/icons/icons.stories.tsx');
+const ICONS_STORIES_PATH = path.join(__dirname, './src/style/foundation/icons/Icons.stories.tsx');
 const PRETTIER_CONFIG_PATH = path.join(__dirname, './.prettierrc.json');
 const prettierConfig = JSON.parse(await fs.readFile(PRETTIER_CONFIG_PATH, 'utf-8'));
 
@@ -66,6 +66,8 @@ export const ${name} = memo(forwardRef<SVGSVGElement, IconProps>((props, ref) =>
       ${svg}
     </IconBase>
     )));
+
+${name}.displayName = '${name}';
 `;
 
 const StoryTemplate = (icons) => `/**
@@ -73,9 +75,11 @@ const StoryTemplate = (icons) => `/**
  * 직접 수정하는 대신 iconsAsset/convert.js를 수정하세요.
  */
 
+import { Primary as PrimaryBlock, Controls, Markdown } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
 import { styled } from 'styled-components';
 
+import IconDocs from './IconDocs.md?raw';
 import { IconBase } from './icon.base';
 
 import {
@@ -89,6 +93,17 @@ const Icons = [
 const meta: Meta = {
   title: 'Foundation/Icons',
   component: IconBase,
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Markdown>{IconDocs}</Markdown>
+          <PrimaryBlock />
+          <Controls />
+        </>
+      ),
+    },
+  },
 };
 export default meta;
 

--- a/src/style/foundation/icons/generated/IcAdbadgeFilled.tsx
+++ b/src/style/foundation/icons/generated/IcAdbadgeFilled.tsx
@@ -31,3 +31,5 @@ export const IcAdbadgeFilled = memo(
     </IconBase>
   ))
 );
+
+IcAdbadgeFilled.displayName = 'IcAdbadgeFilled';

--- a/src/style/foundation/icons/generated/IcAdbadgeLine.tsx
+++ b/src/style/foundation/icons/generated/IcAdbadgeLine.tsx
@@ -28,3 +28,5 @@ export const IcAdbadgeLine = memo(
     </IconBase>
   ))
 );
+
+IcAdbadgeLine.displayName = 'IcAdbadgeLine';

--- a/src/style/foundation/icons/generated/IcArrowDownLine.tsx
+++ b/src/style/foundation/icons/generated/IcArrowDownLine.tsx
@@ -26,3 +26,5 @@ export const IcArrowDownLine = memo(
     </IconBase>
   ))
 );
+
+IcArrowDownLine.displayName = 'IcArrowDownLine';

--- a/src/style/foundation/icons/generated/IcArrowLeftLine.tsx
+++ b/src/style/foundation/icons/generated/IcArrowLeftLine.tsx
@@ -26,3 +26,5 @@ export const IcArrowLeftLine = memo(
     </IconBase>
   ))
 );
+
+IcArrowLeftLine.displayName = 'IcArrowLeftLine';

--- a/src/style/foundation/icons/generated/IcArrowRightLine.tsx
+++ b/src/style/foundation/icons/generated/IcArrowRightLine.tsx
@@ -26,3 +26,5 @@ export const IcArrowRightLine = memo(
     </IconBase>
   ))
 );
+
+IcArrowRightLine.displayName = 'IcArrowRightLine';

--- a/src/style/foundation/icons/generated/IcArrowUpLine.tsx
+++ b/src/style/foundation/icons/generated/IcArrowUpLine.tsx
@@ -26,3 +26,5 @@ export const IcArrowUpLine = memo(
     </IconBase>
   ))
 );
+
+IcArrowUpLine.displayName = 'IcArrowUpLine';

--- a/src/style/foundation/icons/generated/IcBellFilled.tsx
+++ b/src/style/foundation/icons/generated/IcBellFilled.tsx
@@ -32,3 +32,5 @@ export const IcBellFilled = memo(
     </IconBase>
   ))
 );
+
+IcBellFilled.displayName = 'IcBellFilled';

--- a/src/style/foundation/icons/generated/IcBellLine.tsx
+++ b/src/style/foundation/icons/generated/IcBellLine.tsx
@@ -26,3 +26,5 @@ export const IcBellLine = memo(
     </IconBase>
   ))
 );
+
+IcBellLine.displayName = 'IcBellLine';

--- a/src/style/foundation/icons/generated/IcBellmuteLine.tsx
+++ b/src/style/foundation/icons/generated/IcBellmuteLine.tsx
@@ -36,3 +36,5 @@ export const IcBellmuteLine = memo(
     </IconBase>
   ))
 );
+
+IcBellmuteLine.displayName = 'IcBellmuteLine';

--- a/src/style/foundation/icons/generated/IcBlockuserLine.tsx
+++ b/src/style/foundation/icons/generated/IcBlockuserLine.tsx
@@ -46,3 +46,5 @@ export const IcBlockuserLine = memo(
     </IconBase>
   ))
 );
+
+IcBlockuserLine.displayName = 'IcBlockuserLine';

--- a/src/style/foundation/icons/generated/IcBoardFilled.tsx
+++ b/src/style/foundation/icons/generated/IcBoardFilled.tsx
@@ -27,3 +27,5 @@ export const IcBoardFilled = memo(
     </IconBase>
   ))
 );
+
+IcBoardFilled.displayName = 'IcBoardFilled';

--- a/src/style/foundation/icons/generated/IcBoardLine.tsx
+++ b/src/style/foundation/icons/generated/IcBoardLine.tsx
@@ -34,3 +34,5 @@ export const IcBoardLine = memo(
     </IconBase>
   ))
 );
+
+IcBoardLine.displayName = 'IcBoardLine';

--- a/src/style/foundation/icons/generated/IcBookFilled.tsx
+++ b/src/style/foundation/icons/generated/IcBookFilled.tsx
@@ -41,3 +41,5 @@ export const IcBookFilled = memo(
     </IconBase>
   ))
 );
+
+IcBookFilled.displayName = 'IcBookFilled';

--- a/src/style/foundation/icons/generated/IcBookLine.tsx
+++ b/src/style/foundation/icons/generated/IcBookLine.tsx
@@ -61,3 +61,5 @@ export const IcBookLine = memo(
     </IconBase>
   ))
 );
+
+IcBookLine.displayName = 'IcBookLine';

--- a/src/style/foundation/icons/generated/IcCalendarFilled.tsx
+++ b/src/style/foundation/icons/generated/IcCalendarFilled.tsx
@@ -38,3 +38,5 @@ export const IcCalendarFilled = memo(
     </IconBase>
   ))
 );
+
+IcCalendarFilled.displayName = 'IcCalendarFilled';

--- a/src/style/foundation/icons/generated/IcCalendarLine.tsx
+++ b/src/style/foundation/icons/generated/IcCalendarLine.tsx
@@ -41,3 +41,5 @@ export const IcCalendarLine = memo(
     </IconBase>
   ))
 );
+
+IcCalendarLine.displayName = 'IcCalendarLine';

--- a/src/style/foundation/icons/generated/IcCameraFilled.tsx
+++ b/src/style/foundation/icons/generated/IcCameraFilled.tsx
@@ -26,3 +26,5 @@ export const IcCameraFilled = memo(
     </IconBase>
   ))
 );
+
+IcCameraFilled.displayName = 'IcCameraFilled';

--- a/src/style/foundation/icons/generated/IcCameraLine.tsx
+++ b/src/style/foundation/icons/generated/IcCameraLine.tsx
@@ -41,3 +41,5 @@ export const IcCameraLine = memo(
     </IconBase>
   ))
 );
+
+IcCameraLine.displayName = 'IcCameraLine';

--- a/src/style/foundation/icons/generated/IcCameracircleLine.tsx
+++ b/src/style/foundation/icons/generated/IcCameracircleLine.tsx
@@ -20,3 +20,5 @@ export const IcCameracircleLine = memo(
     </IconBase>
   ))
 );
+
+IcCameracircleLine.displayName = 'IcCameracircleLine';

--- a/src/style/foundation/icons/generated/IcCheckLine.tsx
+++ b/src/style/foundation/icons/generated/IcCheckLine.tsx
@@ -26,3 +26,5 @@ export const IcCheckLine = memo(
     </IconBase>
   ))
 );
+
+IcCheckLine.displayName = 'IcCheckLine';

--- a/src/style/foundation/icons/generated/IcCheckcircleFilled.tsx
+++ b/src/style/foundation/icons/generated/IcCheckcircleFilled.tsx
@@ -31,3 +31,5 @@ export const IcCheckcircleFilled = memo(
     </IconBase>
   ))
 );
+
+IcCheckcircleFilled.displayName = 'IcCheckcircleFilled';

--- a/src/style/foundation/icons/generated/IcCheckcircleLine.tsx
+++ b/src/style/foundation/icons/generated/IcCheckcircleLine.tsx
@@ -31,3 +31,5 @@ export const IcCheckcircleLine = memo(
     </IconBase>
   ))
 );
+
+IcCheckcircleLine.displayName = 'IcCheckcircleLine';

--- a/src/style/foundation/icons/generated/IcClipLine.tsx
+++ b/src/style/foundation/icons/generated/IcClipLine.tsx
@@ -56,3 +56,5 @@ export const IcClipLine = memo(
     </IconBase>
   ))
 );
+
+IcClipLine.displayName = 'IcClipLine';

--- a/src/style/foundation/icons/generated/IcCommentFilled.tsx
+++ b/src/style/foundation/icons/generated/IcCommentFilled.tsx
@@ -31,3 +31,5 @@ export const IcCommentFilled = memo(
     </IconBase>
   ))
 );
+
+IcCommentFilled.displayName = 'IcCommentFilled';

--- a/src/style/foundation/icons/generated/IcCommentLine.tsx
+++ b/src/style/foundation/icons/generated/IcCommentLine.tsx
@@ -41,3 +41,5 @@ export const IcCommentLine = memo(
     </IconBase>
   ))
 );
+
+IcCommentLine.displayName = 'IcCommentLine';

--- a/src/style/foundation/icons/generated/IcDotbadgeLine.tsx
+++ b/src/style/foundation/icons/generated/IcDotbadgeLine.tsx
@@ -18,3 +18,5 @@ export const IcDotbadgeLine = memo(
     </IconBase>
   ))
 );
+
+IcDotbadgeLine.displayName = 'IcDotbadgeLine';

--- a/src/style/foundation/icons/generated/IcDotsHorizontalLine.tsx
+++ b/src/style/foundation/icons/generated/IcDotsHorizontalLine.tsx
@@ -24,3 +24,5 @@ export const IcDotsHorizontalLine = memo(
     </IconBase>
   ))
 );
+
+IcDotsHorizontalLine.displayName = 'IcDotsHorizontalLine';

--- a/src/style/foundation/icons/generated/IcDotsVerticalLine.tsx
+++ b/src/style/foundation/icons/generated/IcDotsVerticalLine.tsx
@@ -24,3 +24,5 @@ export const IcDotsVerticalLine = memo(
     </IconBase>
   ))
 );
+
+IcDotsVerticalLine.displayName = 'IcDotsVerticalLine';

--- a/src/style/foundation/icons/generated/IcDownloadLine.tsx
+++ b/src/style/foundation/icons/generated/IcDownloadLine.tsx
@@ -36,3 +36,5 @@ export const IcDownloadLine = memo(
     </IconBase>
   ))
 );
+
+IcDownloadLine.displayName = 'IcDownloadLine';

--- a/src/style/foundation/icons/generated/IcEmojiaddLine.tsx
+++ b/src/style/foundation/icons/generated/IcEmojiaddLine.tsx
@@ -56,3 +56,5 @@ export const IcEmojiaddLine = memo(
     </IconBase>
   ))
 );
+
+IcEmojiaddLine.displayName = 'IcEmojiaddLine';

--- a/src/style/foundation/icons/generated/IcEyeclosedLine.tsx
+++ b/src/style/foundation/icons/generated/IcEyeclosedLine.tsx
@@ -26,3 +26,5 @@ export const IcEyeclosedLine = memo(
     </IconBase>
   ))
 );
+
+IcEyeclosedLine.displayName = 'IcEyeclosedLine';

--- a/src/style/foundation/icons/generated/IcEyeopenLine.tsx
+++ b/src/style/foundation/icons/generated/IcEyeopenLine.tsx
@@ -31,3 +31,5 @@ export const IcEyeopenLine = memo(
     </IconBase>
   ))
 );
+
+IcEyeopenLine.displayName = 'IcEyeopenLine';

--- a/src/style/foundation/icons/generated/IcFoodFilled.tsx
+++ b/src/style/foundation/icons/generated/IcFoodFilled.tsx
@@ -32,3 +32,5 @@ export const IcFoodFilled = memo(
     </IconBase>
   ))
 );
+
+IcFoodFilled.displayName = 'IcFoodFilled';

--- a/src/style/foundation/icons/generated/IcFoodLine.tsx
+++ b/src/style/foundation/icons/generated/IcFoodLine.tsx
@@ -20,3 +20,5 @@ export const IcFoodLine = memo(
     </IconBase>
   ))
 );
+
+IcFoodLine.displayName = 'IcFoodLine';

--- a/src/style/foundation/icons/generated/IcFoodcalendarFilled.tsx
+++ b/src/style/foundation/icons/generated/IcFoodcalendarFilled.tsx
@@ -88,3 +88,5 @@ export const IcFoodcalendarFilled = memo(
     </IconBase>
   ))
 );
+
+IcFoodcalendarFilled.displayName = 'IcFoodcalendarFilled';

--- a/src/style/foundation/icons/generated/IcFoodcalendarLine.tsx
+++ b/src/style/foundation/icons/generated/IcFoodcalendarLine.tsx
@@ -80,3 +80,5 @@ export const IcFoodcalendarLine = memo(
     </IconBase>
   ))
 );
+
+IcFoodcalendarLine.displayName = 'IcFoodcalendarLine';

--- a/src/style/foundation/icons/generated/IcGroundFilled.tsx
+++ b/src/style/foundation/icons/generated/IcGroundFilled.tsx
@@ -28,3 +28,5 @@ export const IcGroundFilled = memo(
     </IconBase>
   ))
 );
+
+IcGroundFilled.displayName = 'IcGroundFilled';

--- a/src/style/foundation/icons/generated/IcGroundLine.tsx
+++ b/src/style/foundation/icons/generated/IcGroundLine.tsx
@@ -42,3 +42,5 @@ export const IcGroundLine = memo(
     </IconBase>
   ))
 );
+
+IcGroundLine.displayName = 'IcGroundLine';

--- a/src/style/foundation/icons/generated/IcHeartLine.tsx
+++ b/src/style/foundation/icons/generated/IcHeartLine.tsx
@@ -27,3 +27,5 @@ export const IcHeartLine = memo(
     </IconBase>
   ))
 );
+
+IcHeartLine.displayName = 'IcHeartLine';

--- a/src/style/foundation/icons/generated/IcHomeFilled.tsx
+++ b/src/style/foundation/icons/generated/IcHomeFilled.tsx
@@ -22,3 +22,5 @@ export const IcHomeFilled = memo(
     </IconBase>
   ))
 );
+
+IcHomeFilled.displayName = 'IcHomeFilled';

--- a/src/style/foundation/icons/generated/IcHomeLine.tsx
+++ b/src/style/foundation/icons/generated/IcHomeLine.tsx
@@ -36,3 +36,5 @@ export const IcHomeLine = memo(
     </IconBase>
   ))
 );
+
+IcHomeLine.displayName = 'IcHomeLine';

--- a/src/style/foundation/icons/generated/IcListLine.tsx
+++ b/src/style/foundation/icons/generated/IcListLine.tsx
@@ -36,3 +36,5 @@ export const IcListLine = memo(
     </IconBase>
   ))
 );
+
+IcListLine.displayName = 'IcListLine';

--- a/src/style/foundation/icons/generated/IcLockFilled.tsx
+++ b/src/style/foundation/icons/generated/IcLockFilled.tsx
@@ -32,3 +32,5 @@ export const IcLockFilled = memo(
     </IconBase>
   ))
 );
+
+IcLockFilled.displayName = 'IcLockFilled';

--- a/src/style/foundation/icons/generated/IcLockLine.tsx
+++ b/src/style/foundation/icons/generated/IcLockLine.tsx
@@ -28,3 +28,5 @@ export const IcLockLine = memo(
     </IconBase>
   ))
 );
+
+IcLockLine.displayName = 'IcLockLine';

--- a/src/style/foundation/icons/generated/IcNewFilled.tsx
+++ b/src/style/foundation/icons/generated/IcNewFilled.tsx
@@ -31,3 +31,5 @@ export const IcNewFilled = memo(
     </IconBase>
   ))
 );
+
+IcNewFilled.displayName = 'IcNewFilled';

--- a/src/style/foundation/icons/generated/IcNewLine.tsx
+++ b/src/style/foundation/icons/generated/IcNewLine.tsx
@@ -31,3 +31,5 @@ export const IcNewLine = memo(
     </IconBase>
   ))
 );
+
+IcNewLine.displayName = 'IcNewLine';

--- a/src/style/foundation/icons/generated/IcNoticeFilled.tsx
+++ b/src/style/foundation/icons/generated/IcNoticeFilled.tsx
@@ -43,3 +43,5 @@ export const IcNoticeFilled = memo(
     </IconBase>
   ))
 );
+
+IcNoticeFilled.displayName = 'IcNoticeFilled';

--- a/src/style/foundation/icons/generated/IcNoticeLine.tsx
+++ b/src/style/foundation/icons/generated/IcNoticeLine.tsx
@@ -47,3 +47,5 @@ export const IcNoticeLine = memo(
     </IconBase>
   ))
 );
+
+IcNoticeLine.displayName = 'IcNoticeLine';

--- a/src/style/foundation/icons/generated/IcPenFilled.tsx
+++ b/src/style/foundation/icons/generated/IcPenFilled.tsx
@@ -42,3 +42,5 @@ export const IcPenFilled = memo(
     </IconBase>
   ))
 );
+
+IcPenFilled.displayName = 'IcPenFilled';

--- a/src/style/foundation/icons/generated/IcPenLine.tsx
+++ b/src/style/foundation/icons/generated/IcPenLine.tsx
@@ -32,3 +32,5 @@ export const IcPenLine = memo(
     </IconBase>
   ))
 );
+
+IcPenLine.displayName = 'IcPenLine';

--- a/src/style/foundation/icons/generated/IcPersonFilled.tsx
+++ b/src/style/foundation/icons/generated/IcPersonFilled.tsx
@@ -25,3 +25,5 @@ export const IcPersonFilled = memo(
     </IconBase>
   ))
 );
+
+IcPersonFilled.displayName = 'IcPersonFilled';

--- a/src/style/foundation/icons/generated/IcPersonLine.tsx
+++ b/src/style/foundation/icons/generated/IcPersonLine.tsx
@@ -26,3 +26,5 @@ export const IcPersonLine = memo(
     </IconBase>
   ))
 );
+
+IcPersonLine.displayName = 'IcPersonLine';

--- a/src/style/foundation/icons/generated/IcPersoncircleLine.tsx
+++ b/src/style/foundation/icons/generated/IcPersoncircleLine.tsx
@@ -20,3 +20,5 @@ export const IcPersoncircleLine = memo(
     </IconBase>
   ))
 );
+
+IcPersoncircleLine.displayName = 'IcPersoncircleLine';

--- a/src/style/foundation/icons/generated/IcPictureFilled.tsx
+++ b/src/style/foundation/icons/generated/IcPictureFilled.tsx
@@ -27,3 +27,5 @@ export const IcPictureFilled = memo(
     </IconBase>
   ))
 );
+
+IcPictureFilled.displayName = 'IcPictureFilled';

--- a/src/style/foundation/icons/generated/IcPictureLine.tsx
+++ b/src/style/foundation/icons/generated/IcPictureLine.tsx
@@ -32,3 +32,5 @@ export const IcPictureLine = memo(
     </IconBase>
   ))
 );
+
+IcPictureLine.displayName = 'IcPictureLine';

--- a/src/style/foundation/icons/generated/IcPinFilled.tsx
+++ b/src/style/foundation/icons/generated/IcPinFilled.tsx
@@ -40,3 +40,5 @@ export const IcPinFilled = memo(
     </IconBase>
   ))
 );
+
+IcPinFilled.displayName = 'IcPinFilled';

--- a/src/style/foundation/icons/generated/IcPinLine.tsx
+++ b/src/style/foundation/icons/generated/IcPinLine.tsx
@@ -32,3 +32,5 @@ export const IcPinLine = memo(
     </IconBase>
   ))
 );
+
+IcPinLine.displayName = 'IcPinLine';

--- a/src/style/foundation/icons/generated/IcPlaycircleFilled.tsx
+++ b/src/style/foundation/icons/generated/IcPlaycircleFilled.tsx
@@ -31,3 +31,5 @@ export const IcPlaycircleFilled = memo(
     </IconBase>
   ))
 );
+
+IcPlaycircleFilled.displayName = 'IcPlaycircleFilled';

--- a/src/style/foundation/icons/generated/IcPlaycircleLine.tsx
+++ b/src/style/foundation/icons/generated/IcPlaycircleLine.tsx
@@ -31,3 +31,5 @@ export const IcPlaycircleLine = memo(
     </IconBase>
   ))
 );
+
+IcPlaycircleLine.displayName = 'IcPlaycircleLine';

--- a/src/style/foundation/icons/generated/IcPlusLine.tsx
+++ b/src/style/foundation/icons/generated/IcPlusLine.tsx
@@ -20,3 +20,5 @@ export const IcPlusLine = memo(
     </IconBase>
   ))
 );
+
+IcPlusLine.displayName = 'IcPlusLine';

--- a/src/style/foundation/icons/generated/IcRankFilled.tsx
+++ b/src/style/foundation/icons/generated/IcRankFilled.tsx
@@ -22,3 +22,5 @@ export const IcRankFilled = memo(
     </IconBase>
   ))
 );
+
+IcRankFilled.displayName = 'IcRankFilled';

--- a/src/style/foundation/icons/generated/IcRankLine.tsx
+++ b/src/style/foundation/icons/generated/IcRankLine.tsx
@@ -22,3 +22,5 @@ export const IcRankLine = memo(
     </IconBase>
   ))
 );
+
+IcRankLine.displayName = 'IcRankLine';

--- a/src/style/foundation/icons/generated/IcRecommentLine.tsx
+++ b/src/style/foundation/icons/generated/IcRecommentLine.tsx
@@ -31,3 +31,5 @@ export const IcRecommentLine = memo(
     </IconBase>
   ))
 );
+
+IcRecommentLine.displayName = 'IcRecommentLine';

--- a/src/style/foundation/icons/generated/IcRefreshLine.tsx
+++ b/src/style/foundation/icons/generated/IcRefreshLine.tsx
@@ -31,3 +31,5 @@ export const IcRefreshLine = memo(
     </IconBase>
   ))
 );
+
+IcRefreshLine.displayName = 'IcRefreshLine';

--- a/src/style/foundation/icons/generated/IcSavecircleFilled.tsx
+++ b/src/style/foundation/icons/generated/IcSavecircleFilled.tsx
@@ -31,3 +31,5 @@ export const IcSavecircleFilled = memo(
     </IconBase>
   ))
 );
+
+IcSavecircleFilled.displayName = 'IcSavecircleFilled';

--- a/src/style/foundation/icons/generated/IcSavecircleLine.tsx
+++ b/src/style/foundation/icons/generated/IcSavecircleLine.tsx
@@ -36,3 +36,5 @@ export const IcSavecircleLine = memo(
     </IconBase>
   ))
 );
+
+IcSavecircleLine.displayName = 'IcSavecircleLine';

--- a/src/style/foundation/icons/generated/IcSchoolcalendarFilled.tsx
+++ b/src/style/foundation/icons/generated/IcSchoolcalendarFilled.tsx
@@ -55,3 +55,5 @@ export const IcSchoolcalendarFilled = memo(
     </IconBase>
   ))
 );
+
+IcSchoolcalendarFilled.displayName = 'IcSchoolcalendarFilled';

--- a/src/style/foundation/icons/generated/IcSchoolcalendarLine.tsx
+++ b/src/style/foundation/icons/generated/IcSchoolcalendarLine.tsx
@@ -50,3 +50,5 @@ export const IcSchoolcalendarLine = memo(
     </IconBase>
   ))
 );
+
+IcSchoolcalendarLine.displayName = 'IcSchoolcalendarLine';

--- a/src/style/foundation/icons/generated/IcSearchLine.tsx
+++ b/src/style/foundation/icons/generated/IcSearchLine.tsx
@@ -31,3 +31,5 @@ export const IcSearchLine = memo(
     </IconBase>
   ))
 );
+
+IcSearchLine.displayName = 'IcSearchLine';

--- a/src/style/foundation/icons/generated/IcSettingLine.tsx
+++ b/src/style/foundation/icons/generated/IcSettingLine.tsx
@@ -20,3 +20,5 @@ export const IcSettingLine = memo(
     </IconBase>
   ))
 );
+
+IcSettingLine.displayName = 'IcSettingLine';

--- a/src/style/foundation/icons/generated/IcShareLine.tsx
+++ b/src/style/foundation/icons/generated/IcShareLine.tsx
@@ -38,3 +38,5 @@ export const IcShareLine = memo(
     </IconBase>
   ))
 );
+
+IcShareLine.displayName = 'IcShareLine';

--- a/src/style/foundation/icons/generated/IcSharecircleFilled.tsx
+++ b/src/style/foundation/icons/generated/IcSharecircleFilled.tsx
@@ -31,3 +31,5 @@ export const IcSharecircleFilled = memo(
     </IconBase>
   ))
 );
+
+IcSharecircleFilled.displayName = 'IcSharecircleFilled';

--- a/src/style/foundation/icons/generated/IcSharecircleLine.tsx
+++ b/src/style/foundation/icons/generated/IcSharecircleLine.tsx
@@ -36,3 +36,5 @@ export const IcSharecircleLine = memo(
     </IconBase>
   ))
 );
+
+IcSharecircleLine.displayName = 'IcSharecircleLine';

--- a/src/style/foundation/icons/generated/IcStarFilled.tsx
+++ b/src/style/foundation/icons/generated/IcStarFilled.tsx
@@ -23,3 +23,5 @@ export const IcStarFilled = memo(
     </IconBase>
   ))
 );
+
+IcStarFilled.displayName = 'IcStarFilled';

--- a/src/style/foundation/icons/generated/IcStarLine.tsx
+++ b/src/style/foundation/icons/generated/IcStarLine.tsx
@@ -22,3 +22,5 @@ export const IcStarLine = memo(
     </IconBase>
   ))
 );
+
+IcStarLine.displayName = 'IcStarLine';

--- a/src/style/foundation/icons/generated/IcThumbDownFilled.tsx
+++ b/src/style/foundation/icons/generated/IcThumbDownFilled.tsx
@@ -49,3 +49,5 @@ export const IcThumbDownFilled = memo(
     </IconBase>
   ))
 );
+
+IcThumbDownFilled.displayName = 'IcThumbDownFilled';

--- a/src/style/foundation/icons/generated/IcThumbDownLine.tsx
+++ b/src/style/foundation/icons/generated/IcThumbDownLine.tsx
@@ -38,3 +38,5 @@ export const IcThumbDownLine = memo(
     </IconBase>
   ))
 );
+
+IcThumbDownLine.displayName = 'IcThumbDownLine';

--- a/src/style/foundation/icons/generated/IcThumbUpFilled.tsx
+++ b/src/style/foundation/icons/generated/IcThumbUpFilled.tsx
@@ -44,3 +44,5 @@ export const IcThumbUpFilled = memo(
     </IconBase>
   ))
 );
+
+IcThumbUpFilled.displayName = 'IcThumbUpFilled';

--- a/src/style/foundation/icons/generated/IcThumbUpLine.tsx
+++ b/src/style/foundation/icons/generated/IcThumbUpLine.tsx
@@ -38,3 +38,5 @@ export const IcThumbUpLine = memo(
     </IconBase>
   ))
 );
+
+IcThumbUpLine.displayName = 'IcThumbUpLine';

--- a/src/style/foundation/icons/generated/IcTimecalendarFilled.tsx
+++ b/src/style/foundation/icons/generated/IcTimecalendarFilled.tsx
@@ -50,3 +50,5 @@ export const IcTimecalendarFilled = memo(
     </IconBase>
   ))
 );
+
+IcTimecalendarFilled.displayName = 'IcTimecalendarFilled';

--- a/src/style/foundation/icons/generated/IcTimecalendarLine.tsx
+++ b/src/style/foundation/icons/generated/IcTimecalendarLine.tsx
@@ -50,3 +50,5 @@ export const IcTimecalendarLine = memo(
     </IconBase>
   ))
 );
+
+IcTimecalendarLine.displayName = 'IcTimecalendarLine';

--- a/src/style/foundation/icons/generated/IcTrashcanFilled.tsx
+++ b/src/style/foundation/icons/generated/IcTrashcanFilled.tsx
@@ -41,3 +41,5 @@ export const IcTrashcanFilled = memo(
     </IconBase>
   ))
 );
+
+IcTrashcanFilled.displayName = 'IcTrashcanFilled';

--- a/src/style/foundation/icons/generated/IcTrashcanLine.tsx
+++ b/src/style/foundation/icons/generated/IcTrashcanLine.tsx
@@ -38,3 +38,5 @@ export const IcTrashcanLine = memo(
     </IconBase>
   ))
 );
+
+IcTrashcanLine.displayName = 'IcTrashcanLine';

--- a/src/style/foundation/icons/generated/IcWarningcircleFilled.tsx
+++ b/src/style/foundation/icons/generated/IcWarningcircleFilled.tsx
@@ -31,3 +31,5 @@ export const IcWarningcircleFilled = memo(
     </IconBase>
   ))
 );
+
+IcWarningcircleFilled.displayName = 'IcWarningcircleFilled';

--- a/src/style/foundation/icons/generated/IcWarningcircleLine.tsx
+++ b/src/style/foundation/icons/generated/IcWarningcircleLine.tsx
@@ -32,3 +32,5 @@ export const IcWarningcircleLine = memo(
     </IconBase>
   ))
 );
+
+IcWarningcircleLine.displayName = 'IcWarningcircleLine';

--- a/src/style/foundation/icons/generated/IcXLine.tsx
+++ b/src/style/foundation/icons/generated/IcXLine.tsx
@@ -36,3 +36,5 @@ export const IcXLine = memo(
     </IconBase>
   ))
 );
+
+IcXLine.displayName = 'IcXLine';

--- a/src/style/foundation/icons/generated/IcXcircleFilled.tsx
+++ b/src/style/foundation/icons/generated/IcXcircleFilled.tsx
@@ -22,3 +22,5 @@ export const IcXcircleFilled = memo(
     </IconBase>
   ))
 );
+
+IcXcircleFilled.displayName = 'IcXcircleFilled';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #60

### 기존 코드에 영향을 미치는 변경사항

- convert.mjs 수정으로 아이콘 컴포넌트에 displayName을 추가했습니다

- convert.mjs 수정으로 아이콘 스토리파일의 파일명을 수정했습니다 (icon~ -> Icon)

![image](https://github.com/yourssu/YDS-React/assets/87255462/f997c0e1-887f-46f9-af26-fe22de94ba22)

## 2️⃣ 알아두시면 좋아요!
아이콘 컴포넌트 수정 or 아이콘 스토리 수정은 모두 `convert.mjs`를 통해서 이루어져야 합니다 👍

스토리 수정한 걸 convert.mjs에 반영해도 되지만 convert.mjs만 수정하고 한번 더 돌리는 게 덜 귀찮을 거 같아요

## 3️⃣ 추후 작업
IcHeartLine 아이콘 수정

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
