### PR TITLE
feat: create SuffixTextField

### DIFF
--- a/src/components/TextField/SuffixTextField/SuffixTextField.stories.tsx
+++ b/src/components/TextField/SuffixTextField/SuffixTextField.stories.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+
+import { Meta, StoryObj } from '@storybook/react';
+
+import { SuffixTextField } from './SuffixTextField';
+
+const meta: Meta<typeof SuffixTextField> = {
+  title: 'Atoms/TextField/SuffixTextField',
+  component: SuffixTextField,
+  parameters: {
+    layout: 'centered',
+  },
+};
+export default meta;
+
+const TextFieldStory = ({ ...textFieldProps }) => {
+  const [value, setValue] = useState('');
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  const newProps = { ...textFieldProps, value, onChange };
+  return <SuffixTextField {...newProps} />;
+};
+
+type Story = StoryObj<typeof SuffixTextField>;
+export const Primary: Story = {
+  args: {
+    fieldLabel: '필드 라벨',
+    helperLabel: '도움말 텍스트',
+    placeholder: '플레이스 홀더',
+    disabled: false,
+    isPositive: false,
+    isNegative: false,
+    width: '350px',
+    suffix: '@soongsil.ac.kr',
+  },
+  render: TextFieldStory,
+};
+
+export const Disabled: Story = {
+  args: {
+    fieldLabel: '필드 라벨',
+    helperLabel: '도움말 텍스트',
+    placeholder: '플레이스 홀더',
+    disabled: true,
+    width: '350px',
+    suffix: '@soongsil.ac.kr',
+  },
+  render: TextFieldStory,
+};
+
+export const Positive: Story = {
+  args: {
+    fieldLabel: '필드 라벨',
+    helperLabel: '도움말 텍스트',
+    placeholder: '플레이스 홀더',
+    disabled: false,
+    isPositive: true,
+    width: '350px',
+    suffix: '@soongsil.ac.kr',
+  },
+  render: TextFieldStory,
+};
+
+export const Negative: Story = {
+  args: {
+    fieldLabel: '필드 라벨',
+    helperLabel: '도움말 텍스트',
+    placeholder: '플레이스 홀더',
+    disabled: false,
+    isNegative: true,
+    width: '350px',
+    suffix: '@soongsil.ac.kr',
+  },
+  render: TextFieldStory,
+};

--- a/src/components/TextField/SuffixTextField/SuffixTextField.tsx
+++ b/src/components/TextField/SuffixTextField/SuffixTextField.tsx
@@ -1,0 +1,7 @@
+import { TextField } from '../TextField';
+
+import { SuffixTextFieldProps } from './SuffixTextField.type';
+
+export const SuffixTextField = ({ ...props }: SuffixTextFieldProps) => {
+  return <TextField suffix={props.suffix} {...props} />;
+};

--- a/src/components/TextField/SuffixTextField/SuffixTextField.tsx
+++ b/src/components/TextField/SuffixTextField/SuffixTextField.tsx
@@ -2,6 +2,6 @@ import { TextField } from '../TextField';
 
 import { SuffixTextFieldProps } from './SuffixTextField.type';
 
-export const SuffixTextField = ({ ...props }: SuffixTextFieldProps) => {
-  return <TextField suffix={props.suffix} {...props} />;
+export const SuffixTextField = ({ suffix, ...props }: SuffixTextFieldProps) => {
+  return <TextField suffix={suffix} {...props} />;
 };

--- a/src/components/TextField/SuffixTextField/SuffixTextField.type.ts
+++ b/src/components/TextField/SuffixTextField/SuffixTextField.type.ts
@@ -1,0 +1,3 @@
+import { TextFieldProps } from '../TextField.type';
+
+export interface SuffixTextFieldProps extends TextFieldProps {}

--- a/src/components/TextField/SuffixTextField/SuffixTextField.type.ts
+++ b/src/components/TextField/SuffixTextField/SuffixTextField.type.ts
@@ -1,3 +1,6 @@
 import { TextFieldProps } from '../TextField.type';
 
-export interface SuffixTextFieldProps extends TextFieldProps {}
+export interface SuffixTextFieldProps extends Omit<TextFieldProps, 'searchPrefix'> {
+  /** TextField 오른쪽에 들어갈 텍스트 */
+  suffix?: string;
+}

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -25,6 +25,7 @@ export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
 
   margin: 8px 0 0 0;
   padding: 12px 16px;
+  gap: 4px;
 
   .suffix-icon {
     visibility: hidden;
@@ -79,6 +80,12 @@ export const StyledTextField = styled.input<StyledTextFieldProps>`
     color: ${({ theme, disabled }) =>
       disabled ? theme.color.textDisabled : theme.color.textTertiary};
   }
+`;
+
+export const StyledSuffixText = styled.span<StyledTextFieldProps>`
+  ${({ theme }) => theme.typo.body2};
+  color: ${({ theme, $isDisabled }) =>
+    $isDisabled ? theme.color.textDisabled : theme.color.textTertiary};
 `;
 
 export const StyledFieldLabel = styled.label<StyledTextFieldProps>`

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,6 +1,7 @@
 import {
   StyledFieldLabel,
   StyledHelperLabel,
+  StyledSuffixText,
   StyledTextField,
   StyledTextFieldWrapper,
 } from './TextField.style';
@@ -31,7 +32,11 @@ export const TextField = ({
       >
         {searchPrefix}
         <StyledTextField {...props} />
-        {suffix}
+        {typeof suffix === 'string' ? (
+          <StyledSuffixText $isDisabled={props.disabled}>{suffix}</StyledSuffixText>
+        ) : (
+          suffix
+        )}
       </StyledTextFieldWrapper>
       {helperLabel && (
         <StyledHelperLabel $isNegative={isNegative} $isDisabled={props.disabled}>

--- a/src/components/TextField/index.ts
+++ b/src/components/TextField/index.ts
@@ -1,2 +1,5 @@
 export { SimpleTextField } from './SimpleTextField/SimpleTextField';
 export type { SimpleTextFieldProps } from './SimpleTextField/SimpleTextField.type';
+
+export { SuffixTextField } from './SuffixTextField/SuffixTextField';
+export type { SuffixTextFieldProps } from './SuffixTextField/SuffixTextField.type';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,3 +27,6 @@ export type { ToastProps, ToastDuration } from './Toast';
 
 export { SimpleTextField } from './TextField';
 export type { SimpleTextFieldProps } from './TextField';
+
+export { SuffixTextField } from './TextField';
+export type { SuffixTextFieldProps } from './TextField';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #59 

미루고 미루던..
TextField를 너무 깔끔하게 작성해두셔서 사실상 작업할 게 크게 없더라구요 👍🏻

### 기존 코드에 영향을 미치지 않는 변경사항

create SuffixTextField

### 기존 코드에 영향을 미치는 변경사항

- suffix가 text일 경우 style 스펙이 달라져서, typeof suffix === 'string' 으로 분기처리를 했습니다.

- 글자와 오른쪽 suffix 간 gap이 존재해서, 추가했습니다.
<img width="207" alt="스크린샷 2024-04-18 오후 4 10 01" src="https://github.com/yourssu/YDS-React/assets/84809236/20f71a5e-fb5b-47d0-921f-ce79e8a89c42">

### 고민중인 부분

지금 TextField가 Focus 여부에 따라 x icon을 보이게 하는 상태인데, 내용을 입력 후 Focus가 없어졌을 땐 x가 보여야 좀 더 자연스럽지 않나 하는 생각이 듭니다. 어떻게 생각하시나용? @nijuy 
|Focus on|Focus off|
|---|---|
|<img width="522" src="https://github.com/yourssu/YDS-React/assets/84809236/1a87053c-b3c4-4293-950b-589d8f0d90a5">|<img width="526" src="https://github.com/yourssu/YDS-React/assets/84809236/1b46fa2f-ad1e-467c-9547-4ff0e5b4fe6a">|

## 2️⃣ 알아두시면 좋아요!

searchPrefix가 문서에는 설정 불가라고 적혀있지만, 사실상 설정은 가능합니다.
설정 불가로 만들려면 props로 내보내지 않아야 하는데, 지금처럼 사용하는 개발자에게 맡기는 게 맞을지 고민이 됩니동

<img width="400" src="https://github.com/yourssu/YDS-React/assets/84809236/fb7219b4-3ab2-443b-83b2-f9e731015e10" />

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
