### PR TITLE
fix: SimpleTextFieldProps에서 사용하지 않는 필드 제거

### DIFF
--- a/src/components/TextField/SimpleTextField/SimpleTextField.tsx
+++ b/src/components/TextField/SimpleTextField/SimpleTextField.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from 'styled-components';
+
 import { IcXLine, IconContext } from '@/style';
 
 import { TextField } from '../TextField';
@@ -10,7 +12,7 @@ export const SimpleTextField = ({ onClickClearButton, ...props }: SimpleTextFiel
       suffix={
         <IconContext.Provider
           value={{
-            color: '#0f0f0f',
+            color: useTheme().color.buttonNormal,
             size: '1rem',
           }}
         >

--- a/src/components/TextField/SimpleTextField/SimpleTextField.type.ts
+++ b/src/components/TextField/SimpleTextField/SimpleTextField.type.ts
@@ -1,6 +1,6 @@
 import { TextFieldProps } from '../TextField.type';
 
-export interface SimpleTextFieldProps extends TextFieldProps {
+export interface SimpleTextFieldProps extends Omit<TextFieldProps, 'suffix' | 'searchPrefix'> {
   /** x 버튼을 클릭했을 때 이벤트 핸들러 */
   onClickClearButton?: () => void;
 }


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #73

### 버그 픽스

이제 `SimpleTextField` 사용시 suffix, searchPrefix 넘기려고 하면 에러 남 (원래 됐었음 -> 이슈에 사진 O)

![suffix](https://github.com/yourssu/YDS-React/assets/87255462/632dd48d-cee6-48d9-8938-b1a1c6755d40)

![prefix](https://github.com/yourssu/YDS-React/assets/87255462/36be0b0e-ce4d-410d-928e-c3e55e7ec81f)

## 2️⃣ 알아두시면 좋아요!

useTheme 써서 아이콘 색 수정해주신 커밋은 체리픽으로 가져와놨어요 🤸‍♀️🍒

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [ ] `main` 브랜치의 최신 코드를 `pull` 받았나요?
