### PR TITLE
fix: storybook missing controls props

### DIFF
--- a/src/components/BoxButton/BoxButton.tsx
+++ b/src/components/BoxButton/BoxButton.tsx
@@ -7,7 +7,20 @@ import { StyledBoxButton } from './BoxButton.style';
 import { BoxButtonProps } from '.';
 
 export const BoxButton = forwardRef<HTMLButtonElement, BoxButtonProps>(
-  ({ size, variant, rounding, isWarned, width, leftIcon, children, rightIcon, ...props }, ref) => {
+  (
+    {
+      size,
+      variant,
+      rounding,
+      isWarned,
+      width,
+      leftIcon,
+      children,
+      rightIcon,
+      ...props
+    }: BoxButtonProps,
+    ref
+  ) => {
     return (
       <StyledBoxButton
         ref={ref}

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -6,7 +6,10 @@ import { StyledCheckBoxWrapper } from './CheckBox.style';
 import { CheckBoxProps } from './CheckBox.type';
 
 export const CheckBox = forwardRef<HTMLDivElement, CheckBoxProps>(
-  ({ size = 'medium', isDisabled = false, onClick, children, isSelected, ...props }, ref) => {
+  (
+    { size = 'medium', isDisabled = false, onClick, children, isSelected, ...props }: CheckBoxProps,
+    ref
+  ) => {
     const inputRef = useRef<HTMLInputElement>(null);
     useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -6,7 +6,7 @@ import { StyledListItem } from './ListItem.style';
 import { ListItemProps } from './ListItem.type';
 
 export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
-  ({ isPressed, leftIcon, rightIcon, children, ...props }, ref) => {
+  ({ isPressed, leftIcon, rightIcon, children, ...props }: ListItemProps, ref) => {
     return (
       <StyledListItem ref={ref} $isPressed={isPressed} $width={props.width} {...props}>
         {leftIcon && (

--- a/src/components/PlainButton/PlainButton.tsx
+++ b/src/components/PlainButton/PlainButton.tsx
@@ -7,7 +7,10 @@ import { StyledPlainButton } from './PlainButton.style';
 import { PlainButtonProps } from '.';
 
 export const PlainButton = forwardRef<HTMLButtonElement, PlainButtonProps>(
-  ({ size, isPointed, isWarned, leftIcon, children, rightIcon, ...props }, ref) => {
+  (
+    { size, isPointed, isWarned, leftIcon, children, rightIcon, ...props }: PlainButtonProps,
+    ref
+  ) => {
     return (
       <StyledPlainButton
         ref={ref}

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -4,7 +4,7 @@ import { StyledToggle, StyledInput, StyledTrack, StyledThumb } from './Toggle.st
 import { ToggleProps } from './Toggle.type';
 
 export const Toggle = forwardRef<HTMLDivElement, ToggleProps>(
-  ({ isDisabled = false, isSelected = false, ...props }, ref) => {
+  ({ isDisabled = false, isSelected = false, ...props }: ToggleProps, ref) => {
     const toggleRef = useRef<HTMLInputElement | null>(null);
     useImperativeHandle(ref, () => toggleRef.current as HTMLInputElement);
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #77

## 2️⃣ 알아두시면 좋아요!

<img width="923" alt="image" src="https://github.com/yourssu/YDS-React/assets/84809236/8f452163-fdd9-4e82-9098-41617053b3b2">

union/ReactReactNode type으로 인식되는 부분에 있어 Storybook을 좀 뜯어봤습니다.

### Storybookjs next branch에서 local storybook 실행 시

![image](https://github.com/yourssu/YDS-React/assets/84809236/f17979eb-575b-46d8-bdee-2daa16448f0c)

이렇게 뜨고 있고, Storybookjs #19580 보시면 문제점에 "We have many duplicated types in our codebase" 언급 확인하실 수 있습니다.

```ts
// code/node_modules/@storybook/csf/dist/index.d.ts
type SBScalarType = SBBaseType & {
    name: 'boolean' | 'string' | 'number' | 'function' | 'symbol';
};
type SBArrayType = SBBaseType & {
    name: 'array';
    value: SBType;
};
type SBObjectType = SBBaseType & {
    name: 'object';
    value: Record<string, SBType>;
};
type SBEnumType = SBBaseType & {
    name: 'enum';
    value: (string | number)[];
};
type SBIntersectionType = SBBaseType & {
    name: 'intersection';
    value: SBType[];
};
type SBUnionType = SBBaseType & {
    name: 'union';
    value: SBType[];
};
type SBOtherType = SBBaseType & {
    name: 'other';
    value: string;
};
```

결론: 수동 문서로 type을 전부 넣어줄 것 아니면 autodocs를 사용하는 이상 간결하게 타입을 표시하게 됨, 스토리북에서 취급하는 예제에서도 union 타입으로 보여줌

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
