### PR TITLE
refactor: 웹에 맞게 Toast.style 수정

### DIFF
--- a/src/components/Toast/HookSource.md
+++ b/src/components/Toast/HookSource.md
@@ -1,4 +1,4 @@
-```typescript
+```tsx
 import { ToastDuration, useToast, Toast } from '@yourssu/design-system-react';
 
 const ToastWrapper = () => {
@@ -11,7 +11,14 @@ const ToastWrapper = () => {
 
   return (
     <div>
-      <button onClick={() => { showToast(toastProps.duration); }}> 버튼 </button>
+      <button
+        onClick={() => {
+          showToast(toastProps.duration);
+        }}
+      >
+        {' '}
+        버튼{' '}
+      </button>
       {isShowToast && <Toast {...toastProps} />}
     </div>
   );

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -21,10 +21,6 @@ const meta: Meta<typeof Toast> = {
           <h2> 주의사항 </h2>
           <ol>
             <li>Toast의 width는 Toast 를 감싸는 컴포넌트의 width에 영향을 받습니다.</li>
-            <li>
-              Toast의 위치는 position: relative 속성이 설정된 가장 가까운 부모 컴포넌트에 의해
-              결정됩니다.
-            </li>
           </ol>
           <br />
           <Title>useToast</Title>
@@ -41,27 +37,13 @@ export default meta;
 
 const ToastStory = ({ ...toastProps }) => {
   return (
-    <div style={{ display: 'flex', gap: '10px', width: '780px', height: '300px' }}>
-      <div
-        style={{
-          backgroundColor: '#c4c4c4',
-          width: '50%',
-          position: 'relative',
-        }}
-      >
-        short duration toast (1.5s)
-        <Toast {...toastProps} />
-      </div>
-      <div
-        style={{
-          backgroundColor: '#c4c4c4',
-          width: '50%',
-          position: 'relative',
-        }}
-      >
-        long duration toast (3s)
-        <Toast duration="long" {...toastProps} />
-      </div>
+    <div
+      style={{
+        width: '500px',
+        height: '150px',
+      }}
+    >
+      <Toast {...toastProps} />
     </div>
   );
 };
@@ -76,15 +58,17 @@ const HookTest = () => {
   return (
     <div
       style={{
-        backgroundColor: '#c4c4c4',
-        width: '1920px',
-        height: '1080px',
+        width: '500px',
+        height: '300px',
+        display: 'flex',
+        justifyContent: 'center',
       }}
     >
       <button
         onClick={() => {
           showToast(toastProps.duration);
         }}
+        style={{ height: 'fit-content' }}
       >
         버튼을 누르면 토스트가 발생합니다
       </button>
@@ -97,12 +81,14 @@ type Story = StoryObj<typeof Toast>;
 export const SingleLine: Story = {
   args: {
     children: '토스트 메시지',
+    duration: 'short',
   },
   render: ToastStory,
 };
 export const MultiLine: Story = {
   args: {
     children: '줄 수가 두 줄 이상이 되는 토스트 메시지입니다.\n좌측 정렬을 해주세요.',
+    duration: 'short',
   },
   render: ToastStory,
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -5,7 +5,6 @@ import { useToast } from '@/hooks/useToast';
 
 import HookSource from './HookSource.md?raw';
 import { Toast } from './Toast';
-import { ToastDuration } from './Toast.type';
 
 const meta: Meta<typeof Toast> = {
   title: 'Component/Toast',
@@ -48,11 +47,7 @@ const ToastStory = ({ ...toastProps }) => {
   );
 };
 
-const HookTest = () => {
-  const toastProps = {
-    children: 'useToast를 사용한 토스트 메시지',
-    duration: 'long' as ToastDuration,
-  };
+const HookTest = ({ ...toastProps }) => {
   const { showToast, isShowToast } = useToast();
 
   return (
@@ -94,4 +89,8 @@ export const MultiLine: Story = {
 };
 export const ToastHook: Story = {
   render: HookTest,
+  args: {
+    children: 'useToast를 사용한 토스트 메시지',
+    duration: 'long',
+  },
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -75,7 +75,11 @@ const HookTest = () => {
 
   return (
     <div
-      style={{ backgroundColor: '#c4c4c4', width: '390px', height: '300px', position: 'relative' }}
+      style={{
+        backgroundColor: '#c4c4c4',
+        width: '1920px',
+        height: '1080px',
+      }}
     >
       <button
         onClick={() => {
@@ -98,7 +102,7 @@ export const SingleLine: Story = {
 };
 export const MultiLine: Story = {
   args: {
-    children: '줄 수가 두 줄 이상이 되는 토스트 메시지입니다. 좌측 정렬을 해주세요.',
+    children: '줄 수가 두 줄 이상이 되는 토스트 메시지입니다.\n좌측 정렬을 해주세요.',
   },
   render: ToastStory,
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import { Stories, Primary as PrimaryBlock, Controls, Title, Markdown } from '@storybook/blocks';
+import { Primary as PrimaryBlock, Controls, Title, Markdown } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
 
 import { useToast } from '@/hooks/useToast';
@@ -25,8 +25,6 @@ const meta: Meta<typeof Toast> = {
           <Title>useToast</Title>
           <span>Toast 컴포넌트를 사용하기 위한 Custom Hook입니다.</span>
           <Markdown>{HookSource}</Markdown>
-          <br />
-          <Stories />
         </>
       ),
     },
@@ -54,7 +52,7 @@ const HookTest = ({ ...toastProps }) => {
     <div
       style={{
         width: '500px',
-        height: '300px',
+        height: '200px',
         display: 'flex',
         justifyContent: 'center',
       }}
@@ -65,7 +63,7 @@ const HookTest = ({ ...toastProps }) => {
         }}
         style={{ height: 'fit-content' }}
       >
-        버튼을 누르면 토스트가 발생합니다
+        Show Toast
       </button>
       {isShowToast && <Toast {...toastProps} />}
     </div>
@@ -73,6 +71,13 @@ const HookTest = ({ ...toastProps }) => {
 };
 
 type Story = StoryObj<typeof Toast>;
+export const ToastHook: Story = {
+  render: HookTest,
+  args: {
+    children: 'useToast를 사용한 토스트 메시지',
+    duration: 'long',
+  },
+};
 export const SingleLine: Story = {
   args: {
     children: '토스트 메시지',
@@ -87,11 +92,4 @@ export const MultiLine: Story = {
     duration: 'short',
   },
   render: ToastStory,
-};
-export const ToastHook: Story = {
-  render: HookTest,
-  args: {
-    children: 'useToast를 사용한 토스트 메시지',
-    duration: 'long',
-  },
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof Toast> = {
           <Controls />
           <h2> 주의사항 </h2>
           <ol>
-            <li>Toast의 width는 Toast 를 감싸는 컴포넌트의 width에 영향을 받습니다.</li>
+            <li>width props 값이 fit-content보다 작을 경우 적용되지 않습니다.</li>
           </ol>
           <br />
           <Title>useToast</Title>
@@ -77,6 +77,7 @@ export const SingleLine: Story = {
   args: {
     children: '토스트 메시지',
     duration: 'short',
+    width: '300px',
   },
   render: ToastStory,
 };

--- a/src/components/Toast/Toast.style.ts
+++ b/src/components/Toast/Toast.style.ts
@@ -40,22 +40,28 @@ const setToastAnimation = ($duration: ToastDuration) => {
 };
 
 export const StyledToastWrapper = styled.div`
-  position: absolute;
-  bottom: 66px;
+  position: fixed;
+  inset: 0px;
   width: 100%;
+  height: 100%;
   padding: 0px 8px;
+  pointer-events: none;
+  display: flex;
+  justify-content: center;
 `;
 
 export const StyledToast = styled.div<StyledToastProps>`
   opacity: 0;
   border-radius: 8px;
-  width: 100%;
+  width: fit-content;
   padding: 16px 24px;
   display: flex;
   justify-content: center;
   background-color: ${({ theme }) => theme.color.toastBG};
   color: ${({ theme }) => theme.color.textBright};
   ${({ theme }) => theme.typo.body2};
-
   ${({ $duration }) => setToastAnimation($duration)};
+  white-space: pre-line;
+  position: absolute;
+  bottom: 66px;
 `;

--- a/src/components/Toast/Toast.style.ts
+++ b/src/components/Toast/Toast.style.ts
@@ -1,9 +1,10 @@
 import { css, keyframes, styled } from 'styled-components';
 
-import { ToastDuration } from './Toast.type';
+import { ToastDuration, ToastProps } from './Toast.type';
 
 interface StyledToastProps {
   $duration: ToastDuration;
+  $width: ToastProps['width'];
 }
 
 const SHORT_DURATION = 1.5;
@@ -53,7 +54,9 @@ export const StyledToastWrapper = styled.div`
 export const StyledToast = styled.div<StyledToastProps>`
   opacity: 0;
   border-radius: 8px;
-  width: fit-content;
+  min-width: fit-content;
+  width: ${({ $width }) => $width};
+  max-width: 100%;
   padding: 16px 24px;
   display: flex;
   justify-content: center;

--- a/src/components/Toast/Toast.style.ts
+++ b/src/components/Toast/Toast.style.ts
@@ -46,25 +46,30 @@ export const StyledToastWrapper = styled.div`
   width: 100%;
   height: 100%;
   padding: 0px 8px;
-  pointer-events: none;
+
   display: flex;
   justify-content: center;
+
+  pointer-events: none;
 `;
 
 export const StyledToast = styled.div<StyledToastProps>`
-  opacity: 0;
-  border-radius: 8px;
+  position: absolute;
+  bottom: 66px;
   min-width: fit-content;
   width: ${({ $width }) => $width};
   max-width: 100%;
-  padding: 16px 24px;
+
   display: flex;
   justify-content: center;
+  padding: 16px 24px;
+  opacity: 0;
+
   background-color: ${({ theme }) => theme.color.toastBG};
+  border-radius: 8px;
   color: ${({ theme }) => theme.color.textBright};
   ${({ theme }) => theme.typo.body2};
-  ${({ $duration }) => setToastAnimation($duration)};
   white-space: pre-line;
-  position: absolute;
-  bottom: 66px;
+
+  ${({ $duration }) => setToastAnimation($duration)};
 `;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,12 +1,12 @@
 import { StyledToast, StyledToastWrapper } from './Toast.style';
 import { ToastProps } from './Toast.type';
 
-export const Toast = ({ children, duration = 'short', ...props }: ToastProps) => {
+export const Toast = ({ children, duration = 'short', width, ...props }: ToastProps) => {
   if (!children) return;
 
   return (
     <StyledToastWrapper>
-      <StyledToast $duration={duration} {...props}>
+      <StyledToast $duration={duration} $width={width} {...props}>
         {children}
       </StyledToast>
     </StyledToastWrapper>

--- a/src/components/Toast/Toast.type.ts
+++ b/src/components/Toast/Toast.type.ts
@@ -5,4 +5,6 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
   /** 지속 시간 (1.5s | 3s)*/
   duration?: ToastDuration;
+  /** Toast의 width */
+  width?: string;
 }


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #79 

### 기존 코드에 영향을 미치지 않는 변경사항

- 웹에서 `Toast`를 사용했을 때 위치, 너비 문제가 있어 웹에 맞게 수정했습니다

  - width를 사용자가 지정할 수 있습니다. 지나치게 작거나 (fit-content 미만) 클 경우 (화면 사이즈 초과) 적용되지 않습니다
  - 스크롤 위치와 관계 없이 현재 화면 기준으로 위치를 수정했습니다 (원래는 absolute로 잡아놔서 스크롤 내려야 보였음)

     ![toast_position](https://github.com/yourssu/YDS-React/assets/87255462/179b7cf4-7b72-49aa-b752-b2a51ec257aa)

- 바뀐 내용에 맞게 문서를 일부 수정했습니다

## 2️⃣ 알아두시면 좋아요!

- 화면 전체에 `StyledToastWrapper`가 뜨고 그 안에 `StyledToast`가 위치하는 형태입니다

  ![toast](https://github.com/yourssu/YDS-React/assets/87255462/24a28982-ca4b-47a2-b290-390d81738123)


## 3️⃣ 추후 작업
- PR 리뷰 기반 수정

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
