### PR TITLE
feat: config react docgen typescript

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,12 +2,25 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      propFilter: (prop) => {
+        if (prop.parent) {
+          return !prop.parent.fileName.includes('node_modules');
+        }
+        return true;
+      },
+    },
+    check: false,
+  },
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-onboarding',
     '@storybook/addon-interactions',
-    '@storybook/addon-mdx-gfm'
+    '@storybook/addon-mdx-gfm',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,6 +6,7 @@ const config: StorybookConfig = {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
       propFilter: (prop) => {
         if (prop.parent) {
           return !prop.parent.fileName.includes('node_modules');


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #77 

![image](https://github.com/yourssu/YDS-React/assets/84809236/1acd326b-f761-4b46-a88f-b551381e7492)

해결 완 😙

## 2️⃣ 알아두시면 좋아요!

[#78 PR comment](https://github.com/yourssu/YDS-React/pull/78)에 union type과 관련해 분석한 내용을 적어두었습니다.
결론은 스토리북에서 취급하는 버그가 아니었고, **react-docgen** 을 추가로 활용합니다.
reactDocgen의 기본 설정은 react-docgen이지만, TypeScript 파일을 적절히 처리하기 위해 react-docgen-typescript를 설정합니다.

forwardRef 활용해서 수정 했었던 속성 누락 문제까지 전부 해결돼서 #78은 닫았습니다.

### undefined type 표시

특정 prop의 타입을 변형하려면 react-docgen-typescript의 출력을 후처리해야 하고, 번들러 로더 설정에서 후처리 수행 스크립트 or 플러그인을 작성해야 합니다.
다만, 플러그인 작성시 모든 TS 파일의 소스 코드에서 undefined를 제거하게 됩니다.
=> 결론: 타입 정보는 그대로 보존합니다.

<img width="279" alt="image" src="https://github.com/yourssu/YDS-React/assets/84809236/c8b611cf-6a36-428e-b4fb-862b3310f2ed">

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
