### PR TITLE
refactor: `OnlyBGColor` 조건 수정

### DIFF
--- a/src/components/Badge/Badge.type.ts
+++ b/src/components/Badge/Badge.type.ts
@@ -1,8 +1,8 @@
-import { SemanticBGColor } from '@/style';
+import { SemanticItemBGColor } from '@/style';
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
   /** 배경 색상 */
-  color?: SemanticBGColor;
+  color?: SemanticItemBGColor;
   /** Badge 안에 들어갈 텍스트 */
   children?: React.ReactNode;
   /** 텍스트 왼쪽에 들어갈 아이콘 */

--- a/src/style/foundation/color/semanticColor/semanticColor.type.ts
+++ b/src/style/foundation/color/semanticColor/semanticColor.type.ts
@@ -99,5 +99,5 @@ export type SemanticColor =
   | SemanticItemColor;
 
 // Utility Types
-type OnlyBGColor<T> = T extends `${string}BG` ? T : never;
-export type SemanticBGColor = OnlyBGColor<SemanticColor>;
+type OnlyItemBGColor<T> = T extends `${string}ItemBG` ? T : never;
+export type SemanticItemBGColor = OnlyItemBGColor<SemanticColor>;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #86 

### 기존 코드에 영향을 미치는 변경사항

- `OnlyBGColor`의 범위를 `이름에 'ItemBG'가 포함되는 타입`으로 수정했습니다

- 관련 타입 이름에 `Item`을 추가했습니다

|변경 전 (v1.0.2)|변경 후|
|:---:|:---:|
|![image](https://github.com/yourssu/YDS-React/assets/87255462/8e478578-f904-44a4-a50b-d0f8906a3811)|![image](https://github.com/yourssu/YDS-React/assets/87255462/9fe2151e-cdc4-43fc-a81e-25ad60fe7869)|
|Badge 컬러로 불가한 색상이 포함됨|피그마와 동일한 옵션만 선택 가능|

## 2️⃣ 알아두시면 좋아요!

컴포넌트 하나만 고려해서 타입을 수정하는 게 문제가 될 수도 있을 거 같아서
나중에 `BG`가 들어간 타입만 쓰게 될 수도 있을지 생각해봤는데,
토스트/툴팁/버튼용 컬러를 한 곳에서 사용할 일이 없을 거라고 생각해서 이렇게 수정해봤습니다

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
