### PR TITLE
fix: duplicate class name in suffix icon

### DIFF
--- a/src/components/TextField/PasswordTextField/PasswordTextField.tsx
+++ b/src/components/TextField/PasswordTextField/PasswordTextField.tsx
@@ -9,23 +9,28 @@ import { TextField } from '../TextField';
 import { PasswordTextFieldProps } from './PasswordTextField.type';
 
 export const PasswordTextField = ({ isMarked = true, ...props }: PasswordTextFieldProps) => {
+  const theme = useTheme();
   const [isMarkedValue, setIsMarkedValue] = useState(isMarked);
+
   const onClickEyeButton = () => {
     setIsMarkedValue((prev) => !prev);
   };
+
   return (
     <TextField
       type={isMarkedValue ? 'password' : 'text'}
       suffix={
         <IconContext.Provider
           value={{
-            color: useTheme().color.buttonNormal,
+            color: theme.color.buttonNormal,
             size: '1.5rem',
           }}
         >
-          <div className="suffix-icon" onClick={onClickEyeButton}>
-            {isMarkedValue ? <IcEyeclosedLine /> : <IcEyeopenLine />}
-          </div>
+          {isMarkedValue ? (
+            <IcEyeclosedLine onClick={onClickEyeButton} />
+          ) : (
+            <IcEyeopenLine onClick={onClickEyeButton} />
+          )}
         </IconContext.Provider>
       }
       {...props}

--- a/src/components/TextField/SearchTextField/SearchTextField.tsx
+++ b/src/components/TextField/SearchTextField/SearchTextField.tsx
@@ -18,9 +18,7 @@ export const SearchTextField = ({ onClickClearButton, ...props }: SearchTextFiel
             size: '1rem',
           }}
         >
-          <div className="suffix-icon clear-icon" onClick={onClickClearButton}>
-            <IcXLine />
-          </div>
+          <IcXLine onClick={onClickClearButton} />
         </IconContext.Provider>
       }
       searchPrefix={

--- a/src/components/TextField/SimpleTextField/SimpleTextField.tsx
+++ b/src/components/TextField/SimpleTextField/SimpleTextField.tsx
@@ -7,18 +7,18 @@ import { TextField } from '../TextField';
 import { SimpleTextFieldProps } from './SimpleTextField.type';
 
 export const SimpleTextField = ({ onClickClearButton, ...props }: SimpleTextFieldProps) => {
+  const theme = useTheme();
+
   return (
     <TextField
       suffix={
         <IconContext.Provider
           value={{
-            color: useTheme().color.buttonNormal,
+            color: theme.color.buttonNormal,
             size: '1rem',
           }}
         >
-          <div className="suffix-icon clear-icon" onClick={onClickClearButton}>
-            <IcXLine />
-          </div>
+          <IcXLine onClick={onClickClearButton} />
         </IconContext.Provider>
       }
       {...props}

--- a/src/components/TextField/SuffixTextField/SuffixTextField.type.ts
+++ b/src/components/TextField/SuffixTextField/SuffixTextField.type.ts
@@ -1,6 +1,3 @@
 import { TextFieldProps } from '../TextField.type';
 
-export interface SuffixTextFieldProps extends Omit<TextFieldProps, 'searchPrefix'> {
-  /** TextField 오른쪽에 들어갈 텍스트 */
-  suffix?: string;
-}
+export interface SuffixTextFieldProps extends Omit<TextFieldProps, 'searchPrefix'> {}

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -45,7 +45,6 @@ export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
   input:focus + ${StyledSuffixIconContainer}, input:active + ${StyledSuffixIconContainer} {
     display: flex;
     cursor: pointer;
-    visibility: visible;
   }
 `;
 

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -27,18 +27,6 @@ export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
   padding: 12px 16px;
   gap: 4px;
 
-  .suffix-icon {
-    visibility: hidden;
-    cursor: pointer;
-  }
-
-  input:focus + .suffix-icon,
-  input:active + .suffix-icon {
-    visibility: visible;
-    display: flex;
-    align-items: center;
-  }
-
   ${({ $isDisabled, $isPositive, $isNegative, theme }) =>
     !$isDisabled &&
     ($isNegative
@@ -49,15 +37,6 @@ export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
         css`
           border: 1px solid ${theme.color.textPointed};
         `)}
-
-  ${({ $isDisabled }) =>
-    $isDisabled &&
-    css`
-      input:focus + .suffix-icon,
-      input:active + .suffix-icon {
-        display: none;
-      }
-    `}
 `;
 
 export const StyledTextField = styled.input<StyledTextFieldProps>`
@@ -90,6 +69,16 @@ export const StyledSuffixText = styled.span<StyledTextFieldProps>`
   ${({ theme }) => theme.typo.body2};
   color: ${({ theme, $isDisabled }) =>
     $isDisabled ? theme.color.textDisabled : theme.color.textTertiary};
+`;
+
+export const StyledSuffixIconContainer = styled.div<StyledTextFieldProps>`
+  display: flex;
+  cursor: pointer;
+  ${({ $isDisabled }) =>
+    $isDisabled &&
+    css`
+      visibility: hidden;
+    `}
 `;
 
 export const StyledFieldLabel = styled.label<StyledTextFieldProps>`

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -42,8 +42,8 @@ export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
           border: 1px solid ${theme.color.textPointed};
         `)}
 
-  input:focus + ${StyledSuffixIconContainer} {
-    display: none;
+  input:focus + ${StyledSuffixIconContainer}, input:active + ${StyledSuffixIconContainer} {
+    display: flex;
     cursor: pointer;
     visibility: visible;
   }

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -12,6 +12,10 @@ interface StyledTextFieldProps {
   $width?: TextFieldProps['width'];
 }
 
+export const StyledSuffixIconContainer = styled.div<StyledTextFieldProps>`
+  display: none;
+`;
+
 export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
   width: ${({ $width }) => $width};
   height: 46px;
@@ -37,6 +41,12 @@ export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
         css`
           border: 1px solid ${theme.color.textPointed};
         `)}
+
+  input:focus + ${StyledSuffixIconContainer} {
+    display: none;
+    cursor: pointer;
+    visibility: visible;
+  }
 `;
 
 export const StyledTextField = styled.input<StyledTextFieldProps>`
@@ -69,16 +79,6 @@ export const StyledSuffixText = styled.span<StyledTextFieldProps>`
   ${({ theme }) => theme.typo.body2};
   color: ${({ theme, $isDisabled }) =>
     $isDisabled ? theme.color.textDisabled : theme.color.textTertiary};
-`;
-
-export const StyledSuffixIconContainer = styled.div<StyledTextFieldProps>`
-  display: flex;
-  cursor: pointer;
-  ${({ $isDisabled }) =>
-    $isDisabled &&
-    css`
-      visibility: hidden;
-    `}
 `;
 
 export const StyledFieldLabel = styled.label<StyledTextFieldProps>`

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,6 +1,7 @@
 import {
   StyledFieldLabel,
   StyledHelperLabel,
+  StyledSuffixIconContainer,
   StyledSuffixText,
   StyledTextField,
   StyledTextFieldWrapper,
@@ -35,7 +36,9 @@ export const TextField = ({
         {typeof suffix === 'string' ? (
           <StyledSuffixText $isDisabled={props.disabled}>{suffix}</StyledSuffixText>
         ) : (
-          suffix
+          <StyledSuffixIconContainer $isDisabled={props.disabled}>
+            {suffix}
+          </StyledSuffixIconContainer>
         )}
       </StyledTextFieldWrapper>
       {helperLabel && (

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -9,10 +9,10 @@ import {
 import { TextFieldProps } from './TextField.type';
 
 export const TextField = ({
-  isNegative,
-  isPositive,
-  isFocused,
-  isTyping,
+  isNegative = false,
+  isPositive = false,
+  isFocused = false,
+  isTyping = false,
   fieldLabel,
   helperLabel,
   suffix,


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #96 

### 버그 픽스

1. className="suffix-icon"이 중복으로 발생하기 때문에, suffix icon을 설정하는 TextField를 2개 이상 사용할 경우 suffix-icon이 정상적으로 렌더링되지 않는 문제가 발생합니다.
=> 기존 div tag를 styled-components로 설정해줌으로써 class name을 랜덤으로 설정하게 됩니다.

|수정 전|수정 후|
|--|--|
|<img width="747" alt="image" src="https://github.com/yourssu/YDS-React/assets/84809236/f1d603bd-2902-4464-8942-275a6492a86c">|<img width="739" alt="image" src="https://github.com/yourssu/YDS-React/assets/84809236/62c352db-2318-4f15-8400-0310e7836a87">|

2. 작업 하면서 다른 boolean 속성들도 undefined로 설정되는 문제가 있다는 것을 발견했습니다. (isMarked와 동일)
=> 기본 값을 모두 설정해주었습니다.

## 2️⃣ 알아두시면 좋아요!

수정 하면서 포커스가 되어 있지 않아도 아이콘이 계속 보이도록 해두었는데, 디자인 소통이 계속 지연되는 것 같아서 우선 이렇게 개발해두는 게 어떠신가요? 포커스 여부에 따라 visibility 속성을 수정해주는 로직이 추가되어야 한다는 이유와 아무리 봐도 이게 더 자연스러운 것 같다는 2가지 이유입니다.

## 3️⃣ 추후 작업

1.1.1 배포

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
