### PR TITLE
fix: shoving searchPrefix in SearchTextField

### DIFF
--- a/src/components/TextField/SearchTextField/SearchTextField.tsx
+++ b/src/components/TextField/SearchTextField/SearchTextField.tsx
@@ -25,7 +25,7 @@ export const SearchTextField = ({ onClickClearButton, ...props }: SearchTextFiel
         <IconContext.Provider
           value={{
             color: theme.color.textTertiary,
-            size: '1.5rem',
+            size: '1.25rem',
           }}
         >
           <IcSearchLine />

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -12,7 +12,7 @@ interface StyledTextFieldProps {
   $width?: TextFieldProps['width'];
 }
 
-export const StyledSuffixIconContainer = styled.div<StyledTextFieldProps>`
+export const StyledSuffixIconContainer = styled.div`
   display: none;
 `;
 

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -16,6 +16,10 @@ export const StyledSuffixIconContainer = styled.div<StyledTextFieldProps>`
   display: none;
 `;
 
+export const StyledSearchPrefixContainer = styled.div`
+  display: flex;
+`;
+
 export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
   width: ${({ $width }) => $width};
   height: 46px;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,6 +1,7 @@
 import {
   StyledFieldLabel,
   StyledHelperLabel,
+  StyledSearchPrefixContainer,
   StyledSuffixIconContainer,
   StyledSuffixText,
   StyledTextField,
@@ -31,14 +32,12 @@ export const TextField = ({
         $isDisabled={props.disabled}
         $width={width}
       >
-        {searchPrefix}
+        <StyledSearchPrefixContainer>{searchPrefix}</StyledSearchPrefixContainer>
         <StyledTextField {...props} />
         {typeof suffix === 'string' ? (
           <StyledSuffixText $isDisabled={props.disabled}>{suffix}</StyledSuffixText>
         ) : (
-          <StyledSuffixIconContainer $isDisabled={props.disabled}>
-            {suffix}
-          </StyledSuffixIconContainer>
+          <StyledSuffixIconContainer>{suffix}</StyledSuffixIconContainer>
         )}
       </StyledTextFieldWrapper>
       {helperLabel && (


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #102 

### 기존 코드에 영향을 미치는 변경사항

피그마 상에서 SearchPrefix icon 크기는 20 * 20이고, div로 감싸면 간단하게 해결 되어서 이렇게 작업했습니다.

|수정 전|수정 후|
|--|--|
|![image](https://github.com/yourssu/YDS-React/assets/84809236/37f0c24b-7e9d-4dbd-9e8e-7a7a94ecb80d)|<img width="249" alt="image" src="https://github.com/yourssu/YDS-React/assets/84809236/1c22be55-0dcc-45b1-adb4-eb584d7f7209">|

추가로 StyledSuffixIconContainer에 타입이 불필요해서 삭제했습니다.

## 3️⃣ 추후 작업

진짜진짜진짜 배포.

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
