### PR TITLE
fix: StyledSearchPrefixContainer rendering when searchPrefix is not present

### DIFF
--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -16,10 +16,6 @@ export const StyledSuffixIconContainer = styled.div`
   display: none;
 `;
 
-export const StyledSearchPrefixContainer = styled.div`
-  display: flex;
-`;
-
 export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
   width: ${({ $width }) => $width};
   height: 46px;

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -46,6 +46,10 @@ export const StyledTextFieldWrapper = styled.div<StyledTextFieldProps>`
     display: flex;
     cursor: pointer;
   }
+
+  svg {
+    flex-shrink: 0;
+  }
 `;
 
 export const StyledTextField = styled.input<StyledTextFieldProps>`

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,7 +1,6 @@
 import {
   StyledFieldLabel,
   StyledHelperLabel,
-  StyledSearchPrefixContainer,
   StyledSuffixIconContainer,
   StyledSuffixText,
   StyledTextField,
@@ -32,7 +31,7 @@ export const TextField = ({
         $isDisabled={props.disabled}
         $width={width}
       >
-        <StyledSearchPrefixContainer>{searchPrefix}</StyledSearchPrefixContainer>
+        {searchPrefix}
         <StyledTextField {...props} />
         {typeof suffix === 'string' ? (
           <StyledSuffixText $isDisabled={props.disabled}>{suffix}</StyledSuffixText>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #104

### 버그 픽스

```tsx
<StyledTextFieldWrapper>
  <StyledSearchPrefixContainer>{searchPrefix}</StyledSearchPrefixContainer>
</StyledTextFieldWrapper>
```

searchPrefix prop 존재 유무를 판단하지 않고 있어서 searchPrefix가 없는 SimpleTextField에도 빈 div가 생기는 중 (보라)

![image](https://github.com/yourssu/YDS-React/assets/87255462/5ad920d4-0240-4da1-8800-4db08b327ecc)

`StyledSearchPrefixContainer`를 삭제해서 searchPrefix prop가 없을 때는 안 그림

![image](https://github.com/yourssu/YDS-React/assets/87255462/2e4ce57c-96f2-4fe5-9f42-d4be021b3b9b)

단, StyledSearchPrefixContainer를 삭제하면 [아이콘 크기가 보장되지 않는 문제](https://github.com/yourssu/YDS-React/issues/102#issue-2300389848)가 재발함

이 문제는 StyledTextFieldWrapper 내부 svg에 flex-shrink: 0을 지정하는 방법으로 해결함

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
