### PR TITLE
fix: `StyledTextField` color 지정

### DIFF
--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -62,6 +62,7 @@ export const StyledTextField = styled.input<StyledTextFieldProps>`
   outline: none;
   ${({ theme }) => theme.typo.body2};
 
+  color: ${({ theme }) => theme.color.textSecondary};
   caret-color: ${({ theme }) => theme.color.textPointed};
 
   &:disabled {


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #113

### 버그 픽스

`TextField`의 input에 text color 지정했습니ㄷ다

![text](https://github.com/yourssu/YDS-React/assets/87255462/e0e9f1e1-ad71-4f97-a4b2-15528fee258c)

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
