### PR TITLE
fix: color 속성이 icon에 적용되지 않는 문제

### DIFF
--- a/src/style/foundation/icons/icon.base.tsx
+++ b/src/style/foundation/icons/icon.base.tsx
@@ -11,7 +11,7 @@ export const IconBase = forwardRef<SVGSVGElement, IconProps>((props, ref) => {
       xmlns="http://www.w3.org/2000/svg"
       width={size ?? '24px'}
       height={size ?? '24px'}
-      fill={color ?? 'current'}
+      fill={color ?? 'currentColor'}
       {...rest}
     >
       {children}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #133

### 버그 픽스

- `current`를 `currentColor`로 수정했습니다.

  icon component의 부모 컴포넌트에서 color 지정 시 icon component에도 적용됩니다!!! ㅠㅠ

  | before | after |
  |:---:|:---:|
  |![image](https://github.com/user-attachments/assets/ea32c6e4-219c-4647-9ee0-c61372cc71d3)|![image](https://github.com/user-attachments/assets/97729e53-273c-4843-9a58-bf22d3f06583)|

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
