### PR TITLE
feat: RadioGroup (RadioButton) 컴포넌트 구현

### DIFF
--- a/src/components/RadioGroup/RadioGroup.context.ts
+++ b/src/components/RadioGroup/RadioGroup.context.ts
@@ -8,9 +8,11 @@ import {
 interface RadioGroupContextProps {
   orientation?: RadioGroupOrientationType;
   size?: RadioGroupSizeType;
+  currentRadioValue?: string;
 }
 
 export const RadioGroupContext = createContext<RadioGroupContextProps>({
   size: undefined,
   orientation: undefined,
+  currentRadioValue: undefined,
 });

--- a/src/components/RadioGroup/RadioGroup.context.ts
+++ b/src/components/RadioGroup/RadioGroup.context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+import {
+  RadioGroupSizeType,
+  RadioGroupOrientationType,
+} from '@/components/RadioGroup/RadioGroup.type';
+
+interface RadioGroupContextProps {
+  orientation?: RadioGroupOrientationType;
+  size?: RadioGroupSizeType;
+}
+
+export const RadioGroupContext = createContext<RadioGroupContextProps>({
+  size: undefined,
+  orientation: undefined,
+});

--- a/src/components/RadioGroup/RadioGroup.mdx
+++ b/src/components/RadioGroup/RadioGroup.mdx
@@ -1,0 +1,14 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as RadioGroupStories from './RadioGroup.stories';
+
+<Meta of={RadioGroupStories} />
+
+# RadioGroup
+
+RadioGroup은 단일 선택을 나타낼 수 있는 요소인 Radio Button을 그룹화하여 사용할 수 있도록 도와주는 컴포넌트입니다.
+
+<Canvas of={RadioGroupStories.Control} />
+<Controls />
+
+<br />
+<br />

--- a/src/components/RadioGroup/RadioGroup.mdx
+++ b/src/components/RadioGroup/RadioGroup.mdx
@@ -13,4 +13,132 @@ RadioGroup은 단일 선택을 나타낼 수 있는 요소인 Radio Button을 �
 <br />
 <br />
 
-## RadioGroup.Item
+## 개발 시 참고하면 좋을 내용
+
+RadioGroup은 단일 선택을 제공할 때에만 사용합니다.  
+다중 선택을 제공해야한다면 Checkbox 혹은 Switch를 사용합니다.
+
+<br />
+<br />
+
+## 사용법
+
+RadioGroup 컴포넌트는 `useRadioGroup` 훅을 불러와 사용합니다.
+
+1. 안전한 typing을 위해 RadioGroup의 value를 나열한 타입을 정의합니다.
+
+```tsx
+type RadioGroupValues = '한국어' | '영어' | '일본어';
+```
+
+2. `useRadioGroup` 훅을 호출합니다.
+
+```tsx
+import { useRadioGroup } from '@yourssu/design-system-react';
+
+const RadioGroup = useRadioGroup<RadioGroupValues>();
+```
+
+3. 반환된 RadioGroup 컴포넌트를 통해 원하는 콘텐츠를 구성합니다.
+
+```tsx
+<RadioGroup size="medium">
+  <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+  <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+  <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+</RadioGroup>
+```
+
+<Canvas of={RadioGroupStories.Usage} />
+
+4. 필요하다면 `useRadioGroup` 훅에 기본으로 선택될 value를 전달합니다.
+
+```tsx
+const RadioGroup = useRadioGroup<RadioGroupValues>('한국어');
+```
+
+<Canvas of={RadioGroupStories.UsageDefault} />
+
+<br />
+<br />
+
+### RadioGroup: size (필수)
+
+RadioGroup.Item 컴포넌트의 크기를 정합니다.  
+가능한 값은 `small`, `medium`, `large` 입니다.
+
+```tsx
+<RadioGroup size="small">...</RadioGroup>
+<RadioGroup size="medium">...</RadioGroup>
+<RadioGroup size="large">...</RadioGroup>
+```
+
+<Canvas of={RadioGroupStories.Size} />
+
+<br />
+<br />
+
+### RadioGroup: orientation (선택)
+
+RadioGroup.Item 컴포넌트들의 정렬 방향을 정합니다.  
+가능한 값은 `vertical`, `horizontal` 이며, 기본값은 `vertical` 입니다.
+
+```tsx
+<RadioGroup size="medium">...</RadioGroup>
+<RadioGroup size="medium" orientation="vertical">...</RadioGroup>
+<RadioGroup size="medium" orientation="horizontal">...</RadioGroup>
+```
+
+<Canvas of={RadioGroupStories.Orientation} />
+
+<br />
+<br />
+
+## 예시
+
+### RadioGroup.Item: disabled
+
+RadioGroup.Item 컴포넌트를 비활성화 상태로 만듭니다.
+
+```tsx
+<RadioGroup size="medium">
+  <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+  <RadioGroup.Item value="영어" disabled>
+    영어
+  </RadioGroup.Item>
+  <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+</RadioGroup>
+```
+
+<Canvas of={RadioGroupStories.Disabled} />
+
+<br />
+<br />
+
+### 변경 감지 이벤트 할당
+
+RadioGroup 컴포넌트에 `onValueChange` 이벤트를 할당하여 변경 감지 이벤트를 처리할 수 있습니다.
+
+```tsx
+import { RadioGroupValueChangeEvent } from '@yourssu/design-system-react';
+```
+
+```tsx
+const RadioGroup = useRadioGroup<RadioGroupValues>('한국어');
+
+const onValueChange = (e: RadioGroupValueChangeEvent) => {
+  const { value, event } = e;
+  alert(`선택된 값: ${value}`);
+  console.log(event);
+};
+
+return (
+  <RadioGroup size="medium" onValueChange={onValueChange}>
+    <RadioGroup.Item value="한국어">한국어입니다</RadioGroup.Item>
+    <RadioGroup.Item value="영어">영어입니다</RadioGroup.Item>
+    <RadioGroup.Item value="일본어">일본어입니다</RadioGroup.Item>
+  </RadioGroup>
+);
+```
+
+<Canvas of={RadioGroupStories.Event} />

--- a/src/components/RadioGroup/RadioGroup.mdx
+++ b/src/components/RadioGroup/RadioGroup.mdx
@@ -126,7 +126,7 @@ import { RadioGroupValueChangeEvent } from '@yourssu/design-system-react';
 ```tsx
 const RadioGroup = useRadioGroup<RadioGroupValues>('한국어');
 
-const onValueChange = (e: RadioGroupValueChangeEvent) => {
+const onValueChange = (e: RadioGroupValueChangeEvent<RadioGroupValues>) => {
   const { value, event } = e;
   alert(`선택된 값: ${value}`);
   console.log(event);

--- a/src/components/RadioGroup/RadioGroup.mdx
+++ b/src/components/RadioGroup/RadioGroup.mdx
@@ -12,3 +12,5 @@ RadioGroup은 단일 선택을 나타낼 수 있는 요소인 Radio Button을 �
 
 <br />
 <br />
+
+## RadioGroup.Item

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -39,13 +39,13 @@ const meta: Meta<RadioGroupProps<string> & RadioGroupItemProps<string>> = {
 export default meta;
 
 const ControlComponent = (args: object) => {
-  const RadioGroup = useRadioGroup<'a' | 'b' | 'c'>('b');
+  const RadioGroup = useRadioGroup<'item-1' | 'item-2' | 'item-3'>('item-1');
 
   return (
     <RadioGroup orientation="vertical" size="large" {...args}>
-      <RadioGroup.Item value="a">Option A</RadioGroup.Item>
-      <RadioGroup.Item value="b">Option B</RadioGroup.Item>
-      <RadioGroup.Item value="c">Option C</RadioGroup.Item>
+      <RadioGroup.Item value="item-1">Item1</RadioGroup.Item>
+      <RadioGroup.Item value="item-2">Item2</RadioGroup.Item>
+      <RadioGroup.Item value="item-3">Item3</RadioGroup.Item>
     </RadioGroup>
   );
 };

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,6 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { RadioGroupItemProps, RadioGroupProps } from '@/components/RadioGroup/RadioGroup.type';
+import {
+  RadioGroupItemProps,
+  RadioGroupProps,
+  RadioGroupValueChangeEvent,
+} from '@/components/RadioGroup/RadioGroup.type';
 import { useRadioGroup } from '@/components/RadioGroup/hooks/useRadioGroup';
 
 const meta: Meta<RadioGroupProps<string> & RadioGroupItemProps<string>> = {
@@ -50,6 +54,137 @@ const ControlComponent = (args: object) => {
   );
 };
 
+const UsageComponent = () => {
+  const RadioGroup = useRadioGroup<'한국어' | '영어' | '일본어'>();
+
+  return (
+    <RadioGroup size="medium">
+      <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+      <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+      <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+    </RadioGroup>
+  );
+};
+
+const UsageDefaultComponent = () => {
+  const RadioGroup = useRadioGroup<'한국어' | '영어' | '일본어'>('한국어');
+
+  return (
+    <RadioGroup size="medium">
+      <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+      <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+      <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+    </RadioGroup>
+  );
+};
+
+const SizeComponent = () => {
+  const RadioGroup = useRadioGroup<'한국어' | '영어' | '일본어'>();
+
+  return (
+    <div style={{ display: 'flex', gap: 48 }}>
+      <RadioGroup size="small">
+        <div>- small</div>
+        <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+        <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+        <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+      </RadioGroup>
+      <RadioGroup size="medium">
+        <div>- medium</div>
+        <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+        <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+        <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+      </RadioGroup>
+      <RadioGroup size="large">
+        <div>- large</div>
+        <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+        <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+        <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+      </RadioGroup>
+    </div>
+  );
+};
+
+const OrientationComponent = () => {
+  const RadioGroup = useRadioGroup<'한국어' | '영어' | '일본어'>();
+
+  return (
+    <div style={{ display: 'flex', gap: 80 }}>
+      <RadioGroup size="small">
+        <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+        <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+        <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+      </RadioGroup>
+      <RadioGroup size="small" orientation="vertical">
+        <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+        <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+        <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+      </RadioGroup>
+      <RadioGroup size="small" orientation="horizontal">
+        <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+        <RadioGroup.Item value="영어">영어</RadioGroup.Item>
+        <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+      </RadioGroup>
+    </div>
+  );
+};
+
+const EventComponent = () => {
+  const RadioGroup = useRadioGroup<'한국어' | '영어' | '일본어'>('한국어');
+
+  const onValueChange = (e: RadioGroupValueChangeEvent<'한국어' | '영어' | '일본어'>) => {
+    const { value, event } = e;
+    alert(`선택된 값: ${value}`);
+    console.log(event);
+  };
+
+  return (
+    <RadioGroup size="medium" onValueChange={onValueChange}>
+      <RadioGroup.Item value="한국어">한국어입니다</RadioGroup.Item>
+      <RadioGroup.Item value="영어">영어입니다</RadioGroup.Item>
+      <RadioGroup.Item value="일본어">일본어입니다</RadioGroup.Item>
+    </RadioGroup>
+  );
+};
+
+const DisabledComponent = () => {
+  const RadioGroup = useRadioGroup<'한국어' | '영어' | '일본어'>();
+
+  return (
+    <RadioGroup size="medium">
+      <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
+      <RadioGroup.Item value="영어" disabled>
+        영어
+      </RadioGroup.Item>
+      <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
+    </RadioGroup>
+  );
+};
+
 export const Control: StoryObj = {
   render: ControlComponent,
+};
+
+export const Usage: StoryObj = {
+  render: UsageComponent,
+};
+
+export const UsageDefault: StoryObj = {
+  render: UsageDefaultComponent,
+};
+
+export const Size: StoryObj = {
+  render: SizeComponent,
+};
+
+export const Orientation: StoryObj = {
+  render: OrientationComponent,
+};
+
+export const Disabled: StoryObj = {
+  render: DisabledComponent,
+};
+
+export const Event: StoryObj = {
+  render: EventComponent,
 };

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { RadioGroupItemProps, RadioGroupProps } from '@/components/RadioGroup/RadioGroup.type';
+import { useRadioGroup } from '@/components/RadioGroup/hooks/useRadioGroup';
+
+const meta: Meta<RadioGroupProps<string> & RadioGroupItemProps<string>> = {
+  title: 'Components/RadioGroup',
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    size: 'medium',
+    orientation: 'vertical',
+  },
+  argTypes: {
+    size: {
+      description: 'RadioGroup.Item의 크기를 정합니다.',
+      control: {
+        type: 'radio',
+      },
+      options: ['small', 'medium', 'large'],
+    },
+    onValueChange: {
+      description: '선택된 RadioGroup.Item이 바뀔 때 호출되는 함수입니다.',
+    },
+    orientation: {
+      description: 'RadioGroup.Item이 나열되는 방향을 정합니다.',
+      control: {
+        type: 'radio',
+      },
+      table: {
+        defaultValue: { summary: 'vertical' },
+      },
+      options: ['vertical', 'horizontal'],
+    },
+  },
+};
+
+export default meta;
+
+const ControlComponent = (args: object) => {
+  const RadioGroup = useRadioGroup<'a' | 'b' | 'c'>('b');
+
+  return (
+    <RadioGroup orientation="vertical" size="large" {...args}>
+      <RadioGroup.Item value="a">Option A</RadioGroup.Item>
+      <RadioGroup.Item value="b">Option B</RadioGroup.Item>
+      <RadioGroup.Item value="c">Option C</RadioGroup.Item>
+    </RadioGroup>
+  );
+};
+
+export const Control: StoryObj = {
+  render: ControlComponent,
+};

--- a/src/components/RadioGroup/RadioGroup.style.ts
+++ b/src/components/RadioGroup/RadioGroup.style.ts
@@ -119,6 +119,7 @@ export const StyledRadioItemLabel = styled.label<StyledRadioItemProps>`
     border-style: solid;
     border-color: ${({ theme }) => theme.semantic.color.lineBasicMedium};
     border-radius: 50%;
+    background-color: transparent;
 
     pointer-events: none;
   }

--- a/src/components/RadioGroup/RadioGroup.style.ts
+++ b/src/components/RadioGroup/RadioGroup.style.ts
@@ -1,0 +1,165 @@
+import { css, styled } from 'styled-components';
+
+import {
+  RadioGroupSizeType,
+  RadioGroupOrientationType,
+} from '@/components/RadioGroup/RadioGroup.type';
+
+interface StyledRadioGroupFieldsetProps {
+  $orientation: RadioGroupOrientationType;
+}
+
+interface StyledRadioItemProps {
+  $size: RadioGroupSizeType;
+}
+
+const getRadioInnerStyle = ($size: RadioGroupSizeType) => {
+  switch ($size) {
+    case 'small':
+      return css`
+        width: 9.5px;
+        height: 9.5px;
+      `;
+    case 'medium':
+      return css`
+        width: 12px;
+        height: 12px;
+      `;
+    case 'large':
+      return css`
+        width: 14px;
+        height: 14px;
+      `;
+    default:
+      return '';
+  }
+};
+
+const getRadioButtonStyle = ($size: RadioGroupSizeType) => {
+  switch ($size) {
+    case 'small':
+      return css`
+        width: 16px;
+        height: 16px;
+        border-width: 1px;
+      `;
+    case 'medium':
+      return css`
+        width: 20px;
+        height: 20px;
+        border-width: 1.25px;
+      `;
+    case 'large':
+      return css`
+        width: 24px;
+        height: 24px;
+        border-width: 1.5px;
+      `;
+    default:
+      return '';
+  }
+};
+
+const getDisabledRadioButtonStyle = ($size: RadioGroupSizeType) => {
+  switch ($size) {
+    case 'small':
+      return css`
+        border-width: 3.25px;
+      `;
+    case 'medium':
+      return css`
+        border-width: 4px;
+      `;
+    case 'large':
+      return css`
+        border-width: 5px;
+      `;
+    default:
+      return '';
+  }
+};
+
+export const StyledRadioGroupFieldset = styled.fieldset<StyledRadioGroupFieldsetProps>`
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: ${({ $orientation }) => ($orientation === 'horizontal' ? 'row' : 'column')};
+  gap: 16px;
+`;
+
+export const StyledRadioItemLabel = styled.label<StyledRadioItemProps>`
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+
+  input[type='radio'] {
+    appearance: none;
+    outline: 0;
+    position: absolute;
+    width: 0;
+    height: 0;
+  }
+
+  &:has([type='radio']:disabled) {
+    cursor: not-allowed;
+  }
+
+  button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    ${({ $size }) => getRadioButtonStyle($size)}
+    border-style: solid;
+    border-color: ${({ theme }) => theme.semantic.color.lineBasicMedium};
+    border-radius: 50%;
+
+    pointer-events: none;
+  }
+
+  [data-radio-content='true'] {
+    color: ${({ theme }) => theme.semantic.color.textBasicSecondary};
+    ${({ $size, theme }) => $size === 'small' && theme.typo.C2_Rg_12}
+    ${({ $size, theme }) => $size === 'medium' && theme.typo.B3_Rg_14}
+    ${({ $size, theme }) => $size === 'large' && theme.typo.B1_Rg_16}
+  }
+
+  input[type='radio']:checked ~ button {
+    border-color: ${({ theme }) => theme.semantic.color.lineBrandPrimary};
+  }
+
+  input[type='radio']:checked ~ [data-radio-content='true'] {
+    color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
+  }
+
+  input[type='radio']:disabled ~ button {
+    border-color: ${({ theme }) => theme.semantic.color.lineBasicMedium};
+    ${({ $size }) => getDisabledRadioButtonStyle($size)}
+  }
+
+  input[type='radio']:disabled ~ [data-radio-content='true'] {
+    color: ${({ theme }) => theme.semantic.color.textBasicDisabled};
+  }
+
+  .inner {
+    ${({ $size }) => getRadioInnerStyle($size)}
+
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.semantic.color.buttonRadioUnselected};
+  }
+
+  input[type='radio']:checked ~ button .inner {
+    background-color: ${({ theme }) => theme.semantic.color.buttonRadioSelected};
+  }
+
+  input[type='radio']:disabled ~ button .inner {
+    opacity: 0;
+    visibility: hidden;
+  }
+`;

--- a/src/components/RadioGroup/RadioGroup.style.ts
+++ b/src/components/RadioGroup/RadioGroup.style.ts
@@ -122,6 +122,10 @@ export const StyledRadioItemLabel = styled.label<StyledRadioItemProps>`
     background-color: transparent;
 
     pointer-events: none;
+
+    &:focus {
+      outline: 1px solid black;
+    }
   }
 
   [data-radio-content='true'] {

--- a/src/components/RadioGroup/RadioGroup.type.ts
+++ b/src/components/RadioGroup/RadioGroup.type.ts
@@ -1,0 +1,20 @@
+export type RadioGroupOrientationType = 'horizontal' | 'vertical';
+export type RadioGroupSizeType = 'small' | 'medium' | 'large';
+
+export interface RadioGroupValueChangeEvent<Values extends string> {
+  value: Values;
+  event: React.ChangeEvent<HTMLFieldSetElement>;
+}
+
+export interface RadioGroupProps<Values extends string> {
+  size: RadioGroupSizeType;
+  children: React.ReactNode;
+  orientation?: RadioGroupOrientationType;
+  onValueChange?: (e: RadioGroupValueChangeEvent<Values>) => void;
+}
+
+export interface RadioGroupItemProps<Values extends string> {
+  value: Values;
+  children: React.ReactNode;
+  disabled?: boolean;
+}

--- a/src/components/RadioGroup/hooks/useRadioGroup.tsx
+++ b/src/components/RadioGroup/hooks/useRadioGroup.tsx
@@ -1,0 +1,102 @@
+import { useContext, useId, useRef } from 'react';
+
+import { RadioGroupContext } from '@/components/RadioGroup/RadioGroup.context';
+import {
+  StyledRadioGroupFieldset,
+  StyledRadioItemLabel,
+} from '@/components/RadioGroup/RadioGroup.style';
+import { RadioGroupItemProps, RadioGroupProps } from '@/components/RadioGroup/RadioGroup.type';
+
+export const useRadioGroup = <Values extends string>(initialValue?: Values) => {
+  const radioGroupName = useId();
+  const groupRef = useRef<HTMLFieldSetElement>(null);
+
+  const RadioGroupItemComponent = ({
+    value,
+    children,
+    disabled = false,
+  }: RadioGroupItemProps<Values>) => {
+    const ref = useRef<HTMLLabelElement>(null);
+    const { orientation, size } = useContext(RadioGroupContext);
+
+    const getButtonElementFrom = (node: ChildNode | null) => {
+      if (node instanceof HTMLLabelElement) return node.querySelector('button');
+      return null;
+    };
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!ref.current || !groupRef.current || !orientation) return;
+
+      const previousButton = getButtonElementFrom(ref.current.previousSibling);
+      const nextButton = getButtonElementFrom(ref.current.nextSibling);
+      const firstButton = getButtonElementFrom(groupRef.current.firstChild);
+      const lastButton = getButtonElementFrom(groupRef.current.lastChild);
+
+      if (!firstButton || !lastButton) return;
+
+      const previousKey = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+      const nextKey = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+
+      if (e.code === previousKey) {
+        const button = previousButton || lastButton;
+        button.click();
+        button.focus();
+      }
+
+      if (e.code === nextKey) {
+        const button = nextButton || firstButton;
+        button.click();
+        button.focus();
+      }
+
+      if (e.code === 'Space' || e.code === 'Enter') {
+        e.preventDefault();
+        e.currentTarget.closest('label')?.click();
+        e.currentTarget.focus();
+      }
+    };
+
+    if (!size) return null;
+
+    return (
+      <StyledRadioItemLabel $size={size} ref={ref}>
+        <input
+          type="radio"
+          value={value}
+          name={radioGroupName}
+          defaultChecked={initialValue === value}
+          disabled={disabled}
+        />
+
+        <button onKeyDown={onKeyDown}>
+          <div className="inner" />
+        </button>
+
+        <div data-radio-content>{children}</div>
+      </StyledRadioItemLabel>
+    );
+  };
+
+  const RadioGroupComponent = ({
+    size,
+    children,
+    orientation = 'vertical',
+    onValueChange,
+  }: RadioGroupProps<Values>) => {
+    const onInput = (e: React.ChangeEvent<HTMLFieldSetElement>) => {
+      const { target } = e;
+      if (!(target instanceof HTMLInputElement)) return;
+      onValueChange?.({ value: target.value as Values, event: e });
+    };
+
+    return (
+      <RadioGroupContext.Provider value={{ orientation, size }}>
+        <StyledRadioGroupFieldset $orientation={orientation} onInput={onInput} ref={groupRef}>
+          {children}
+        </StyledRadioGroupFieldset>
+      </RadioGroupContext.Provider>
+    );
+  };
+
+  return Object.assign(RadioGroupComponent, { Item: RadioGroupItemComponent });
+};

--- a/src/components/RadioGroup/hooks/useRadioGroup.tsx
+++ b/src/components/RadioGroup/hooks/useRadioGroup.tsx
@@ -18,7 +18,7 @@ export const useRadioGroup = <Values extends string>(initialValue?: Values) => {
   }: RadioGroupItemProps<Values>) => {
     const ref = useRef<HTMLLabelElement>(null);
     const { orientation, size, currentRadioValue } = useContext(RadioGroupContext);
-    const thisChecked = currentRadioValue === value;
+    const thisChecked = currentRadioValue === value && !disabled;
 
     const getButtonElementFrom = (node: ChildNode | null) => {
       if (node instanceof HTMLLabelElement) return node.querySelector('button');

--- a/src/components/RadioGroup/index.ts
+++ b/src/components/RadioGroup/index.ts
@@ -1,0 +1,2 @@
+export { useRadioGroup } from './hooks/useRadioGroup';
+export type * from './RadioGroup.type';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -30,3 +30,12 @@ export type { TabsProps, TabListProps, TabProps, TabPanelProps } from './Tabs';
 
 export { Fab } from './Fab';
 export type { FabHierarchy, FabProps, FabSize } from './Fab';
+
+export { useRadioGroup } from './RadioGroup';
+export type {
+  RadioGroupProps,
+  RadioGroupItemProps,
+  RadioGroupSizeType,
+  RadioGroupOrientationType,
+  RadioGroupValueChangeEvent,
+} from './RadioGroup';

--- a/src/style/foundation/color/semanticColor/semanticColor.type.ts
+++ b/src/style/foundation/color/semanticColor/semanticColor.type.ts
@@ -25,6 +25,8 @@ export type SemanticTextStatusColor = MergeVariants<'text', 'status', StatusVari
 
 export type SemanticLineBasicColor = MergeVariants<'line', 'basic', 'light' | 'medium' | 'strong'>;
 
+export type SemanticLineBrandColor = MergeVariants<'line', 'brand', 'primary'>;
+
 export type SemanticLineStatusColor = MergeVariants<'line', 'status', StatusVariant>;
 
 export type SemanticButtonBoxPrimaryColor = MergeVariants<
@@ -102,6 +104,7 @@ export type SemanticColorType =
   | SemanticTextBrandColor
   | SemanticTextStatusColor
   | SemanticLineBasicColor
+  | SemanticLineBrandColor
   | SemanticLineStatusColor
   | SemanticButtonBoxPrimaryColor
   | SemanticButtonBoxSecondaryColor

--- a/src/style/foundation/color/semanticColor/semanticColorPalette.ts
+++ b/src/style/foundation/color/semanticColor/semanticColorPalette.ts
@@ -29,6 +29,8 @@ export const semanticColorPalette: SemanticColorPalette = {
   lineBasicMedium: primitiveColorPalette.gray200,
   lineBasicStrong: primitiveColorPalette.gray300,
 
+  lineBrandPrimary: primitiveColorPalette.violet500,
+
   lineStatusNegative: primitiveColorPalette.statusRedMain,
   lineStatusPositive: primitiveColorPalette.violet500,
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

RadioGroup (RadioButton) 컴포넌트를 구현했습니다.

피그마상 컴포넌트 네이밍은 RadioButton이지만,  
실제로 단일 RadioButton으로 사용되는 경우는 없습니다.

따라서 RadioButton들의 목록을 쉽게 관리할 수 있도록  
RadioGroup 컴포넌트로 대체하여 구현하였습니다.

( 다른 컴포넌트 라이브러리들도 RadioButton 대신 RadioGroup 을 구현하는 방식으로 진행함 )

![스크린샷 2024-08-12 00 34 22](https://github.com/user-attachments/assets/78a97dac-da0c-412a-82d5-3dcb6df25aeb)

- resolved #142 

<br />

### 기존 코드에 영향을 미치지 않는 변경사항

`src/components/RadioGroup` 를 추가했습니다.

<br />

### 기존 코드에 영향을 미치는 변경사항

시맨틱 토큰 `semantic.color.lineBrandPrimary` 를 추가했습니다.

<br />

### 버그 픽스

## 2️⃣ 알아두시면 좋아요!

`Tabs` 컴포넌트의 사용법과 동일하게, `useRadioGroup` 훅을 호출하여 사용하는 방식입니다.

최대한 type-safe 하도록 구현했습니다.

```tsx
const RadioGroup = useRadioGroup<'한국어' | '영어' | '일본어'>();

return (
  <RadioGroup size="medium">
    <RadioGroup.Item value="한국어">한국어</RadioGroup.Item>
    <RadioGroup.Item value="영어">영어</RadioGroup.Item>
    <RadioGroup.Item value="일본어">일본어</RadioGroup.Item>
  </RadioGroup>
);
```

## 3️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
- [x] 빌드 체크 및 다른 프로젝트에서 의도한대로 작동하는지 확인
