### PR TITLE
feat: TextField 컴포넌트 구현

### DIFF
--- a/src/components/TextField/TextField.context.ts
+++ b/src/components/TextField/TextField.context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+interface TextFieldContextProps {
+  isError?: boolean;
+  disabled?: boolean;
+}
+
+export const TextFieldContext = createContext<TextFieldContextProps>({
+  isError: undefined,
+  disabled: undefined,
+});

--- a/src/components/TextField/TextField.context.ts
+++ b/src/components/TextField/TextField.context.ts
@@ -1,11 +1,18 @@
 import { createContext } from 'react';
 
-interface TextFieldContextProps {
-  isError?: boolean;
-  disabled?: boolean;
-}
+import { TextFieldContextProps } from './TextField.type';
 
-export const TextFieldContext = createContext<TextFieldContextProps>({
-  isError: undefined,
-  disabled: undefined,
+type TextFieldInnerContextProps = {
+  text: string;
+} & TextFieldContextProps;
+
+export const textFieldDefaultProps: TextFieldContextProps = {
+  isError: false,
+  disabled: false,
+  maxLength: Infinity,
+};
+
+export const TextFieldContext = createContext<TextFieldInnerContextProps>({
+  ...textFieldDefaultProps,
+  text: '',
 });

--- a/src/components/TextField/TextField.mdx
+++ b/src/components/TextField/TextField.mdx
@@ -103,6 +103,31 @@ import { TextField } from '@yourssu/design-system-react';
 <br />
 <br />
 
+### 너비 지정
+
+TextField 컴포넌트는 기본적으로 유동적인 너비를 위해 `width` 가 100%로 지정되어 있습니다.
+
+부모 컴포넌트에 `width`를 지정하여 TextField의 너비를 조절해주세요.
+
+```tsx
+<div style={{ width: '300px' }}>
+  <TextField placeholder="이름을 입력해주세요...">
+    <TextField.Label>이름</TextField.Label>
+  </TextField>
+</div>
+
+<div style={{ width: '500px' }}>
+  <TextField placeholder="이름을 입력해주세요...">
+    <TextField.Label>이름</TextField.Label>
+  </TextField>
+</div>
+```
+
+<Canvas of={TextFieldStories.Width} withSource="none" />
+
+<br />
+<br />
+
 ## 예시
 
 ### isError

--- a/src/components/TextField/TextField.mdx
+++ b/src/components/TextField/TextField.mdx
@@ -1,0 +1,16 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as TextFieldStories from './TextField.stories.tsx';
+import { TextField } from './TextField';
+import React from 'react';
+
+<Meta of={TextFieldStories} />
+
+# TextField
+
+Textfield는 사용자가 텍스트나 정보를 입력하고 편집할 수 있는 컴포넌트입니다.
+
+<Canvas of={TextFieldStories.Control} />
+<Controls />
+
+<br />
+<br />

--- a/src/components/TextField/TextField.mdx
+++ b/src/components/TextField/TextField.mdx
@@ -14,3 +14,210 @@ Textfield는 사용자가 텍스트나 정보를 입력하고 편집할 수 있�
 
 <br />
 <br />
+
+## 사용법
+
+기본 사용법은 아래와 같습니다.
+
+```tsx
+import { TextField } from '@yourssu/design-system-react';
+```
+
+```tsx
+<TextField />
+```
+
+<Canvas of={TextFieldStories.Usage} withSource="none" />
+
+<br />
+<br />
+
+### placeholder
+
+`placeholder` prop을 통해 TextField에 placeholder를 추가할 수 있습니다.
+
+```tsx
+<TextField placeholder="입력해주세요..." />
+```
+
+<Canvas of={TextFieldStories.Placeholder} withSource="none" />
+
+<br />
+<br />
+
+### Label
+
+`TextField.Label`을 통해 TextField에 Label을 추가할 수 있습니다.
+
+```tsx
+<TextField placeholder="이름을 입력해주세요...">
+  <TextField.Label>이름</TextField.Label>
+</TextField>
+```
+
+<Canvas of={TextFieldStories.Label} withSource="none" />
+
+<br />
+<br />
+
+### Helper Text
+
+`TextField.HelperText`을 통해 TextField에 Helper Text를 추가할 수 있습니다.
+
+`Label` 아래에 `HelperText`를 위치시킬 필요는 없지만, 선언적 코드 작성을 위하여 권장됩니다.
+
+```tsx
+// 권장하는 선언 방식
+<TextField placeholder="이름을 입력해주세요...">
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField.HelperText>
+
+
+// 사용은 가능, 권장하지 않음
+<TextField placeholder="이름을 입력해주세요...">
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+  <TextField.Label>이름</TextField.Label>
+</TextField.HelperText>
+```
+
+<Canvas of={TextFieldStories.HelperText} withSource="none" />
+
+<br />
+<br />
+
+### maxLength
+
+`maxLength` prop을 통해 TextField에 최대 글자수를 제한할 수 있습니다.
+
+이 프로퍼티를 사용하면, Helper Text에 현재 입력된 글자수와 최대 글자수를 표시할 수 있으며, 기존 Helper Text는 대체됩니다.
+
+```tsx
+<TextField placeholder="이름을 입력해주세요..." maxLength={10}>
+  <TextField.HelperText>제가 대체됩니다!</TextField.HelperText>
+</TextField>
+```
+
+<Canvas of={TextFieldStories.MaxLength} withSource="none" />
+
+<br />
+<br />
+
+## 예시
+
+### isError
+
+`isError` 속성을 통해 TextField에 에러 상태임을 나타낼 수 있습니다.
+
+```tsx
+<TextField placeholder="이름을 입력해주세요..." isError>
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField>
+```
+
+<Canvas of={TextFieldStories.Error} withSource="none" />
+
+<br />
+<br />
+
+### disabled
+
+`disabled` 속성을 통해 `TextField`을 사용할 수 없게 막습니다.
+
+이때, 에러 상태에 대한 색상은 제거됩니다.
+
+```tsx
+<TextField placeholder="이름을 입력해주세요..." disabled>
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField>
+
+
+<TextField placeholder="이름을 입력해주세요..." disabled isError>
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField>
+```
+
+<Canvas of={TextFieldStories.Disabled} withSource="none" />
+
+<br />
+<br />
+
+### 삭제 버튼 클릭시 이벤트 처리
+
+`onClearButtonClick` 속성을 통해 삭제 버튼 클릭시 원하는 이벤트를 처리할 수 있습니다.
+
+```tsx
+const onClearButtonClick = () => {
+  alert('삭제 버튼 클릭!');
+};
+
+<TextField placeholder="이름을 입력해주세요..." onClearButtonClick={onClearButtonClick}>
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField>;
+```
+
+<Canvas of={TextFieldStories.OnClearButtonClick} withSource="none" />
+
+<br />
+<br />
+
+### 외부에서 상태 관리
+
+기본적으로 컴포넌트 내부에서 상태를 관리하지만, 외부에서 상태를 관리하고 싶을 때 `onChange` 속성을 사용할 수 있습니다.
+
+```tsx
+const [_, setValue] = React.useState('');
+
+const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  setValue(e.target.value);
+};
+
+<TextField placeholder="이름을 입력해주세요..." onChange={onChange}>
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField>;
+```
+
+<Canvas of={TextFieldStories.OnChange} withSource="none" />
+
+<br />
+<br />
+
+### 기본값 설정
+
+`defaultValue` 속성을 통해 TextField의 기본값을 설정할 수 있습니다.
+
+```tsx
+<TextField placeholder="이름을 입력해주세요..." defaultValue="홍길동">
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField>
+```
+
+<Canvas of={TextFieldStories.DefaultValue} withSource="none" />
+
+단 value 속성과 함께 사용한다면, value 속성이 우선적으로 적용됩니다.
+
+```tsx
+const [value, setValue] = useState('김철수');
+
+const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  setValue(e.target.value);
+};
+
+<TextField
+  placeholder="이름을 입력해주세요..."
+  value={value}
+  onChange={onChange}
+  defaultValue="홍길동"
+>
+  <TextField.Label>이름</TextField.Label>
+  <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+</TextField>;
+```
+
+<Canvas of={TextFieldStories.DefaultValueWithValue} withSource="none" />

--- a/src/components/TextField/TextField.mdx
+++ b/src/components/TextField/TextField.mdx
@@ -71,14 +71,14 @@ import { TextField } from '@yourssu/design-system-react';
 <TextField placeholder="이름을 입력해주세요...">
   <TextField.Label>이름</TextField.Label>
   <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
-</TextField.HelperText>
+</TextField>
 
 
 // 사용은 가능, 권장하지 않음
 <TextField placeholder="이름을 입력해주세요...">
   <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
   <TextField.Label>이름</TextField.Label>
-</TextField.HelperText>
+</TextField>
 ```
 
 <Canvas of={TextFieldStories.HelperText} withSource="none" />

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { Meta, StoryObj } from '@storybook/react';
 
 import { TextField } from './TextField';
@@ -7,6 +9,38 @@ const meta: Meta<typeof TextField> = {
   component: TextField,
   parameters: {
     layout: 'centered',
+  },
+  args: {
+    isError: false,
+    disabled: false,
+    placeholder: 'text here',
+  },
+  argTypes: {
+    isError: {
+      description: 'TextField의 에러 상태를 결정하는 속성',
+      control: { type: 'boolean' },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+    disabled: {
+      description: 'TextField의 비활성화를 결정하는 속성',
+      control: { type: 'boolean' },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+    maxLength: {
+      description: '입력할 수 있는 최대 길이를 지정하는 속성',
+      control: { type: 'number' },
+      table: {
+        defaultValue: { summary: Infinity },
+      },
+    },
+    placeholder: {
+      description: 'TextField의 placeholder를 지정하는 속성',
+      control: { type: 'text' },
+    },
   },
 };
 
@@ -21,6 +55,149 @@ const ControlComponent = (args: object) => {
   );
 };
 
+const OnChangeComponent = () => {
+  const [value, setValue] = useState('');
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  return (
+    <>
+      <span>입력한 텍스트: {value}</span>
+      <br />
+      <br />
+      <TextField onChange={onChange} placeholder="이름을 입력해주세요...">
+        <TextField.Label>Label</TextField.Label>
+        <TextField.HelperText>Helper Text</TextField.HelperText>
+      </TextField>
+    </>
+  );
+};
+
+const DefaultValueWithValueComponent = () => {
+  const [value, setValue] = useState('김철수');
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  return (
+    <TextField
+      placeholder="이름을 입력해주세요..."
+      value={value}
+      defaultValue="홍길동"
+      onChange={onChange}
+    >
+      <TextField.Label>이름</TextField.Label>
+      <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+    </TextField>
+  );
+};
+
 export const Control: StoryObj = {
   render: ControlComponent,
+};
+
+export const Usage: StoryObj = {
+  render: () => <TextField />,
+};
+
+export const Placeholder: StoryObj = {
+  render: () => <TextField placeholder="입력해주세요..." />,
+};
+
+export const Label: StoryObj = {
+  render: () => (
+    <TextField placeholder="이름을 입력해주세요...">
+      <TextField.Label>이름</TextField.Label>
+    </TextField>
+  ),
+};
+
+export const HelperText: StoryObj = {
+  render: () => (
+    <>
+      <TextField placeholder="이름을 입력해주세요...">
+        <TextField.Label>이름</TextField.Label>
+        <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+      </TextField>
+
+      <br />
+      <br />
+
+      <TextField placeholder="이름을 입력해주세요...">
+        <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+        <TextField.Label>이름</TextField.Label>
+      </TextField>
+    </>
+  ),
+};
+
+export const MaxLength: StoryObj = {
+  render: () => (
+    <TextField placeholder="이름을 입력해주세요..." maxLength={10}>
+      <TextField.HelperText>제가 대체됩니다!</TextField.HelperText>
+    </TextField>
+  ),
+};
+
+export const Error: StoryObj = {
+  render: () => (
+    <TextField placeholder="이름을 입력해주세요..." isError>
+      <TextField.Label>이름</TextField.Label>
+      <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+    </TextField>
+  ),
+};
+
+export const Disabled: StoryObj = {
+  render: () => (
+    <>
+      <TextField placeholder="이름을 입력해주세요..." disabled>
+        <TextField.Label>이름</TextField.Label>
+        <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+      </TextField>
+
+      <br />
+      <br />
+
+      <TextField placeholder="이름을 입력해주세요..." disabled isError>
+        <TextField.Label>이름</TextField.Label>
+        <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+      </TextField>
+    </>
+  ),
+};
+
+export const OnClearButtonClick: StoryObj = {
+  render: () => {
+    const onClearButtonClick = () => {
+      alert('삭제 버튼 클릭!');
+    };
+
+    return (
+      <TextField placeholder="이름을 입력해주세요..." onClearButtonClick={onClearButtonClick}>
+        <TextField.Label>이름</TextField.Label>
+        <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+      </TextField>
+    );
+  },
+};
+
+export const OnChange: StoryObj = {
+  render: OnChangeComponent,
+};
+
+export const DefaultValue: StoryObj = {
+  render: () => (
+    <TextField placeholder="이름을 입력해주세요..." defaultValue="홍길동">
+      <TextField.Label>이름</TextField.Label>
+      <TextField.HelperText>신분증상 이름을 입력해주세요.</TextField.HelperText>
+    </TextField>
+  ),
+};
+
+export const DefaultValueWithValue: StoryObj = {
+  render: DefaultValueWithValueComponent,
 };

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { TextField } from './TextField';
+
+const meta: Meta<typeof TextField> = {
+  title: 'Components/TextField',
+  component: TextField,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+
+const ControlComponent = (args: object) => {
+  return (
+    <TextField {...args}>
+      <TextField.Label>Label</TextField.Label>
+      <TextField.HelperText>Helper Text</TextField.HelperText>
+    </TextField>
+  );
+};
+
+export const Control: StoryObj = {
+  render: ControlComponent,
+};

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -201,3 +201,27 @@ export const DefaultValue: StoryObj = {
 export const DefaultValueWithValue: StoryObj = {
   render: DefaultValueWithValueComponent,
 };
+
+export const Width: StoryObj = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+      }}
+    >
+      <div style={{ width: '300px' }}>
+        <TextField placeholder="이름을 입력해주세요...">
+          <TextField.Label>이름</TextField.Label>
+        </TextField>
+      </div>
+
+      <div style={{ width: '500px' }}>
+        <TextField placeholder="이름을 입력해주세요...">
+          <TextField.Label>이름</TextField.Label>
+        </TextField>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -85,5 +85,6 @@ export const StyledClearButton = styled.button`
     display: flex;
     justify-content: center;
     align-items: center;
+    color: ${({ theme }) => theme.semantic.color.iconBasicTertiary};
   }
 `;

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -30,7 +30,8 @@ export const StyledTextFieldInput = styled.input<{ $isError: boolean }>`
     $isError ? theme.semantic.color.lineStatusNegative : theme.semantic.color.lineStatusPositive};
   border-radius: ${({ theme }) => theme.semantic.radius.m}px;
 
-  caret-color: ${({ theme }) => theme.semantic.color.lineStatusPositive};
+  caret-color: ${({ theme, $isError }) =>
+    $isError ? theme.semantic.color.lineStatusNegative : theme.semantic.color.lineStatusPositive};
 
   ${({ theme }) => theme.typo.B1_Rg_16}
   color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
@@ -67,7 +68,7 @@ export const StyledTextFieldHelperText = styled.div<{ $isError: boolean }>`
     $isError ? theme.semantic.color.lineStatusNegative : theme.semantic.color.textBasicTertiary};
 `;
 
-export const StyledClearButton = styled.button`
+export const StyledClearButton = styled.button<{ $isError: boolean }>`
   position: absolute;
   top: 50%;
   right: 16px;

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -30,6 +30,8 @@ export const StyledTextFieldInput = styled.input<{ $isError: boolean }>`
     $isError ? theme.semantic.color.lineStatusNegative : theme.semantic.color.lineStatusPositive};
   border-radius: ${({ theme }) => theme.semantic.radius.m}px;
 
+  caret-color: ${({ theme }) => theme.semantic.color.lineStatusPositive};
+
   ${({ theme }) => theme.typo.B1_Rg_16}
   color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
 

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -1,0 +1,87 @@
+import { styled } from 'styled-components';
+
+export const StyledTextFieldContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const StyledTextFieldInputContainer = styled.div`
+  order: 1;
+
+  position: relative;
+  width: 100%;
+`;
+
+export const StyledTextFieldInput = styled.input<{ $isError: boolean }>`
+  box-sizing: border-box;
+  width: 100%;
+  outline: 0;
+
+  padding: 12px 16px;
+  padding-right: calc(16px * 2 + 20px);
+  background-color: ${({ theme }) => theme.semantic.color.bgBasicLight};
+
+  border-width: ${({ $isError }) => ($isError ? 1 : 0)}px;
+  border-style: solid;
+  border-color: ${({ theme, $isError }) =>
+    $isError ? theme.semantic.color.lineStatusNegative : theme.semantic.color.lineStatusPositive};
+  border-radius: ${({ theme }) => theme.semantic.radius.m}px;
+
+  ${({ theme }) => theme.typo.B1_Rg_16}
+  color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
+
+  &::placeholder {
+    ${({ theme }) => theme.typo.B1_Rg_16}
+    color: ${({ theme }) => theme.semantic.color.textBasicTertiary};
+  }
+
+  &:focus {
+    margin: -1px;
+    border-width: 1px;
+  }
+
+  &:disabled,
+  &:disabled::placeholder {
+    color: ${({ theme }) => theme.semantic.color.textBasicDisabled};
+    cursor: not-allowed;
+  }
+`;
+
+export const StyledTextFieldLabel = styled.label`
+  order: 0;
+
+  ${({ theme }) => theme.typo.C2_Rg_12}
+  color: ${({ theme }) => theme.semantic.color.textBasicTertiary};
+`;
+
+export const StyledTextFieldHelperText = styled.div<{ $isError: boolean }>`
+  order: 2;
+
+  ${({ theme }) => theme.typo.C2_Rg_12}
+  color: ${({ theme, $isError }) =>
+    $isError ? theme.semantic.color.lineStatusNegative : theme.semantic.color.textBasicTertiary};
+`;
+
+export const StyledRemoveButton = styled.button`
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  cursor: pointer;
+
+  width: fit-content;
+  height: fit-content;
+
+  border: 0;
+  border-radius: 50%;
+  background-color: transparent;
+
+  svg {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+`;

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -65,7 +65,7 @@ export const StyledTextFieldHelperText = styled.div<{ $isError: boolean }>`
     $isError ? theme.semantic.color.lineStatusNegative : theme.semantic.color.textBasicTertiary};
 `;
 
-export const StyledRemoveButton = styled.button`
+export const StyledClearButton = styled.button`
   position: absolute;
   top: 50%;
   right: 16px;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -101,6 +101,7 @@ export const TextField = Object.assign(
                 $isError={isError && !disabled}
                 ref={inputRef}
                 type="text"
+                defaultValue={undefined}
                 value={text}
                 onChange={onChange}
                 disabled={disabled}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -49,7 +49,7 @@ const ClearButton = ({ inputRef, setText, onClick }: ClearButtonProps) => {
     inputRef.current.dispatchEvent(new Event('input', { bubbles: true }));
   };
 
-  const onClickHadler = () => {
+  const onClickHandler = () => {
     if (!inputRef.current) return;
 
     inputRef.current.focus();
@@ -59,7 +59,7 @@ const ClearButton = ({ inputRef, setText, onClick }: ClearButtonProps) => {
   };
 
   return (
-    <StyledClearButton className="clear-button" onClick={onClickHadler}>
+    <StyledClearButton className="clear-button" onClick={onClickHandler}>
       <IcCancelFilled size="20px" />
     </StyledClearButton>
   );

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -34,7 +34,7 @@ const HelperText = ({ children }: React.PropsWithChildren<unknown>) => {
   );
 };
 
-const ClearButton = ({ inputRef, setText, onClick }: ClearButtonProps) => {
+const ClearButton = ({ inputRef, isError, setText, onClick }: ClearButtonProps) => {
   const triggerClearEvent = () => {
     if (!inputRef.current) return;
 
@@ -59,7 +59,7 @@ const ClearButton = ({ inputRef, setText, onClick }: ClearButtonProps) => {
   };
 
   return (
-    <StyledClearButton className="clear-button" onClick={onClickHandler}>
+    <StyledClearButton className="clear-button" onClick={onClickHandler} $isError={isError}>
       <IcCancelFilled size="20px" />
     </StyledClearButton>
   );
@@ -110,7 +110,12 @@ export const TextField = Object.assign(
                 maxLength={maxLength}
               />
               {text && !disabled && (
-                <ClearButton inputRef={inputRef} setText={setText} onClick={onClearButtonClick} />
+                <ClearButton
+                  inputRef={inputRef}
+                  isError={isError}
+                  setText={setText}
+                  onClick={onClearButtonClick}
+                />
               )}
             </StyledTextFieldInputContainer>
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,0 +1,86 @@
+import { forwardRef, useContext, useImperativeHandle, useRef, useState } from 'react';
+
+import { IcCancelFilled } from '@/style';
+
+import { TextFieldContext } from './TextField.context';
+import {
+  StyledRemoveButton,
+  StyledTextFieldContainer,
+  StyledTextFieldHelperText,
+  StyledTextFieldInput,
+  StyledTextFieldInputContainer,
+  StyledTextFieldLabel,
+} from './TextField.style';
+import { ClearButtonProps, TextFieldProps } from './TextField.type';
+
+const Label = ({ children }: React.PropsWithChildren<unknown>) => {
+  return <StyledTextFieldLabel>{children}</StyledTextFieldLabel>;
+};
+
+const HelperText = ({ children }: React.PropsWithChildren<unknown>) => {
+  const { isError, disabled } = useContext(TextFieldContext);
+  if (isError === undefined || disabled === undefined) return null;
+  return (
+    <StyledTextFieldHelperText $isError={isError && !disabled}>
+      {children}
+    </StyledTextFieldHelperText>
+  );
+};
+
+const ClearButton = ({ inputRef, setText }: ClearButtonProps) => {
+  const onClick = () => {
+    if (!inputRef.current) return;
+
+    inputRef.current.focus();
+    setText('');
+  };
+
+  return (
+    <StyledRemoveButton className="clear-button" onClick={onClick}>
+      <IcCancelFilled size="20px" />
+    </StyledRemoveButton>
+  );
+};
+
+export const TextField = Object.assign(
+  forwardRef<HTMLInputElement, React.PropsWithChildren<TextFieldProps>>(
+    ({ children, isError = false, disabled = false, ...props }, ref) => {
+      const inputRef = useRef<HTMLInputElement>(null);
+      const [text, setText] = useState('');
+
+      const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setText(e.currentTarget.value);
+      };
+
+      useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+      return (
+        <TextFieldContext.Provider value={{ isError, disabled }}>
+          <StyledTextFieldContainer>
+            <StyledTextFieldInputContainer>
+              <StyledTextFieldInput
+                {...props}
+                $isError={isError && !disabled}
+                ref={inputRef}
+                type="text"
+                placeholder="input text"
+                value={text}
+                onChange={onChange}
+                disabled={disabled}
+                spellCheck={false}
+                tabIndex={0}
+              />
+              {text && !disabled && <ClearButton inputRef={inputRef} setText={setText} />}
+            </StyledTextFieldInputContainer>
+
+            {children}
+          </StyledTextFieldContainer>
+        </TextFieldContext.Provider>
+      );
+    }
+  ),
+  {
+    Label,
+    HelperText,
+  }
+);

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -4,7 +4,7 @@ import { IcCancelFilled } from '@/style';
 
 import { TextFieldContext } from './TextField.context';
 import {
-  StyledRemoveButton,
+  StyledClearButton,
   StyledTextFieldContainer,
   StyledTextFieldHelperText,
   StyledTextFieldInput,
@@ -36,9 +36,9 @@ const ClearButton = ({ inputRef, setText }: ClearButtonProps) => {
   };
 
   return (
-    <StyledRemoveButton className="clear-button" onClick={onClick}>
+    <StyledClearButton className="clear-button" onClick={onClick}>
       <IcCancelFilled size="20px" />
-    </StyledRemoveButton>
+    </StyledClearButton>
   );
 };
 

--- a/src/components/TextField/TextField.type.ts
+++ b/src/components/TextField/TextField.type.ts
@@ -13,6 +13,7 @@ export type TextFieldProps = Partial<TextFieldContextProps> &
 
 export interface ClearButtonProps {
   inputRef: React.RefObject<HTMLInputElement>;
+  isError: boolean;
   setText: React.Dispatch<React.SetStateAction<string>>;
   onClick?: () => void;
 }

--- a/src/components/TextField/TextField.type.ts
+++ b/src/components/TextField/TextField.type.ts
@@ -5,11 +5,14 @@ export interface TextFieldContextProps {
 }
 
 export type TextFieldProps = Partial<TextFieldContextProps> &
-  React.HTMLAttributes<HTMLInputElement> & {
+  React.InputHTMLAttributes<HTMLInputElement> & {
+    value?: string;
     defaultValue?: string;
+    onClearButtonClick?: () => void;
   };
 
 export interface ClearButtonProps {
   inputRef: React.RefObject<HTMLInputElement>;
   setText: React.Dispatch<React.SetStateAction<string>>;
+  onClick?: () => void;
 }

--- a/src/components/TextField/TextField.type.ts
+++ b/src/components/TextField/TextField.type.ts
@@ -1,7 +1,13 @@
-export interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
-  isError?: boolean;
-  disabled?: boolean;
+export interface TextFieldContextProps {
+  isError: boolean;
+  disabled: boolean;
+  maxLength: number;
 }
+
+export type TextFieldProps = Partial<TextFieldContextProps> &
+  React.HTMLAttributes<HTMLInputElement> & {
+    defaultValue?: string;
+  };
 
 export interface ClearButtonProps {
   inputRef: React.RefObject<HTMLInputElement>;

--- a/src/components/TextField/TextField.type.ts
+++ b/src/components/TextField/TextField.type.ts
@@ -1,0 +1,9 @@
+export interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
+  isError?: boolean;
+  disabled?: boolean;
+}
+
+export interface ClearButtonProps {
+  inputRef: React.RefObject<HTMLInputElement>;
+  setText: React.Dispatch<React.SetStateAction<string>>;
+}

--- a/src/components/TextField/index.ts
+++ b/src/components/TextField/index.ts
@@ -1,0 +1,2 @@
+export { TextField } from './TextField';
+export type { TextFieldProps } from './TextField.type';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -45,3 +45,6 @@ export type {
 
 export { Textarea } from './Textarea';
 export type { TextareaProps } from './Textarea';
+
+export { TextField } from './TextField';
+export type { TextFieldProps } from './TextField';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #149 

TextField 컴포넌트를 구현했어요.

https://github.com/user-attachments/assets/6e94a169-c252-4bf8-be0d-0d7aeaf95b5b

## 2️⃣ 추후 작업

아무래도 제공하는 props나 기능적으로 @seocylucky 가 구현한 `Textarea` 컴포넌트와 기능적으로 일치할 거 같은데요,

Helper Text 부분을 저는 compound component 로 구현한 것과는 달리, 
@seocylucky 는 props 방식으로 구현했어요.

```tsx
// 저의 방식
<TextField>
  <TextField.HelperText>도움말</TextField>
</TextField>

// 체리 방식
<TextField helperText="도움말" />
```

이 부분에 일관성을 가지기 위해 얘기할 시간이 필요해보여요.

<br />

++ 그리고 머지할 때 index.ts 컨필릭 해결할게요

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
- [x] 빌드 및 다른 프로젝트에서의 구동 테스트 완료