### PR TITLE
docs: BoxButton, TextButton 컴포넌트 문서에 아이콘 관련 내용을 추가

### DIFF
--- a/src/components/BoxButton/BoxButton.mdx
+++ b/src/components/BoxButton/BoxButton.mdx
@@ -69,6 +69,19 @@ import { BoxButton } from '@yourssu/design-system-react';
 
 <Canvas of={BoxButtonStories.Width} withSource="none" />
 
+### leftIcon / rightIcon
+
+`leftIcon` 또는 `rightIcon` prop으로 원하는 아이콘을 삽입합니다.<br />
+아이콘과 텍스트는 동일한 색상으로 스타일링되어 있으므로, 별도의 색상을 지정하지 말아 주세요.
+
+```tsx
+<BoxButton size="large" hierarchy="primary" leftIcon={<IcExternalLinkLine />}>
+  with leftIcon
+</BoxButton>
+```
+
+<Canvas of={BoxButtonStories.WithIcon} withSource="none" />
+
 ### BoxButton 클릭 시 이벤트 할당
 
 `onClick` 메서드를 이용하여 원하는 이벤트를 할당할 수 있습니다.

--- a/src/components/BoxButton/BoxButton.stories.tsx
+++ b/src/components/BoxButton/BoxButton.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+import { IcExternalLinkLine } from '@/style';
+
 import { BoxButton } from './BoxButton';
 
 const meta: Meta<typeof BoxButton> = {
@@ -100,4 +102,17 @@ export const Click: Story = {
       alert('BoxButton을 클릭했습니다');
     },
   },
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <BoxButton size="large" hierarchy="primary" leftIcon={<IcExternalLinkLine />}>
+        with leftIcon
+      </BoxButton>
+      <BoxButton size="large" hierarchy="primary" disabled rightIcon={<IcExternalLinkLine />}>
+        with rightIcon
+      </BoxButton>
+    </div>
+  ),
 };

--- a/src/components/BoxButton/BoxButton.style.ts
+++ b/src/components/BoxButton/BoxButton.style.ts
@@ -15,6 +15,11 @@ const getHierarchyStyle = ($hierarchy: BoxButtonHierarchy) => {
         background-color: ${({ theme }) => theme.semantic.color.buttonBoxPrimaryEnabled};
         color: ${({ theme }) => theme.semantic.color.textBasicWhite};
         border: none;
+
+        svg {
+          fill: ${({ theme }) => theme.semantic.color.iconBasicWhite};
+        }
+
         &:hover {
           cursor: pointer;
           background-color: ${({ theme }) => theme.semantic.color.buttonBoxPrimaryPressed};
@@ -25,6 +30,11 @@ const getHierarchyStyle = ($hierarchy: BoxButtonHierarchy) => {
         background-color: ${({ theme }) => theme.semantic.color.buttonBoxSecondaryEnabled};
         color: ${({ theme }) => theme.semantic.color.textBrandSecondary};
         border: none;
+
+        svg {
+          fill: ${({ theme }) => theme.semantic.color.iconBrandSecondary};
+        }
+
         &:hover {
           cursor: pointer;
           background-color: ${({ theme }) => theme.semantic.color.buttonBoxSecondaryPressed};
@@ -35,6 +45,11 @@ const getHierarchyStyle = ($hierarchy: BoxButtonHierarchy) => {
         background-color: ${({ theme }) => theme.semantic.color.buttonBoxTertiaryEnabled};
         color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
         border: 1px solid ${({ theme }) => theme.semantic.color.lineBasicMedium};
+
+        svg {
+          fill: ${({ theme }) => theme.semantic.color.iconBasicPrimary};
+        }
+
         &:hover {
           cursor: pointer;
           background-color: ${({ theme }) => theme.semantic.color.buttonBoxTertiaryPressed};
@@ -149,5 +164,9 @@ export const StyledBoxButton = styled.button<StyledBoxButtonProps>`
     ${({ $hierarchy }) => getDisabledStyle($hierarchy)}
     color: ${({ theme }) => theme.semantic.color.textBasicDisabled};
     cursor: not-allowed;
+
+    svg {
+      fill: ${({ theme }) => theme.semantic.color.iconBasicDisabledStrong};
+    }
   }
 `;

--- a/src/components/TextButton/TextButton.mdx
+++ b/src/components/TextButton/TextButton.mdx
@@ -69,6 +69,19 @@ import { TextButton } from '@yourssu/design-system-react';
 
 <Canvas of={TextButtonStories.Width} withSource="none" />
 
+### leftIcon / rightIcon
+
+`leftIcon` 또는 `rightIcon` prop으로 원하는 아이콘을 삽입합니다.<br />
+아이콘과 텍스트는 동일한 색상으로 스타일링되어 있으므로, 별도의 색상을 지정하지 말아 주세요.
+
+```tsx
+<TextButton size="medium" hierarchy="primary" leftIcon={<IcExternalLinkLine />}>
+  with leftIcon
+</TextButton>
+```
+
+<Canvas of={TextButtonStories.WithIcon} withSource="none" />
+
 ### TextButton 클릭 시 이벤트 할당
 
 `onClick` 메서드를 이용하여 원하는 이벤트를 할당할 수 있습니다.

--- a/src/components/TextButton/TextButton.stories.tsx
+++ b/src/components/TextButton/TextButton.stories.tsx
@@ -98,3 +98,16 @@ export const Click: Story = {
     },
   },
 };
+
+export const WithIcon: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <TextButton size="medium" hierarchy="primary" leftIcon={<IcExternalLinkLine />}>
+        with leftIcon
+      </TextButton>
+      <TextButton size="medium" hierarchy="primary" disabled rightIcon={<IcExternalLinkLine />}>
+        with rightIcon
+      </TextButton>
+    </div>
+  ),
+};

--- a/src/components/TextButton/TextButton.style.ts
+++ b/src/components/TextButton/TextButton.style.ts
@@ -15,6 +15,11 @@ const getHierarchyStyle = ($hierarchy: TextButtonHierarchy) => {
         background-color: ${({ theme }) => theme.semantic.color.buttonTextPrimaryEnabled};
         color: ${({ theme }) => theme.semantic.color.textBrandPrimary};
         border: none;
+
+        svg {
+          fill: ${({ theme }) => theme.semantic.color.iconBrandPrimary};
+        }
+
         &:hover {
           cursor: pointer;
           background-color: ${({ theme }) => theme.semantic.color.buttonTextPrimaryPressed};
@@ -25,6 +30,11 @@ const getHierarchyStyle = ($hierarchy: TextButtonHierarchy) => {
         background-color: ${({ theme }) => theme.semantic.color.buttonTextSecondaryEnabled};
         color: ${({ theme }) => theme.semantic.color.textBasicTertiary};
         border: none;
+
+        svg {
+          fill: ${({ theme }) => theme.semantic.color.iconBasicTertiary};
+        }
+
         &:hover {
           cursor: pointer;
           background-color: ${({ theme }) => theme.semantic.color.buttonTextSecondaryPressed};
@@ -97,5 +107,9 @@ export const StyledTextButton = styled.button<StyledTextButtonProps>`
     ${({ $hierarchy }) => getDisabledStyle($hierarchy)}
     color: ${({ theme }) => theme.semantic.color.textBasicDisabled};
     cursor: not-allowed;
+
+    svg {
+      fill: ${({ theme }) => theme.semantic.color.iconBasicDisabledStrong};
+    }
   }
 `;

--- a/src/style/foundation/color/semanticColor/semanticColor.type.ts
+++ b/src/style/foundation/color/semanticColor/semanticColor.type.ts
@@ -84,7 +84,11 @@ export type SemanticButtonRadioColor = MergeVariants<
   SelectableVariantWithDisabled
 >;
 
-export type SemanticIconBasicColor = MergeVariants<'icon', 'basic', StaticBasicVariant>;
+export type SemanticIconBasicColor = MergeVariants<
+  'icon',
+  'basic',
+  StaticBasicVariant | 'disabledStrong'
+>;
 
 export type SemanticIconBrandColor = MergeVariants<'icon', 'brand', StaticBrandVariant>;
 

--- a/src/style/foundation/color/semanticColor/semanticColorPalette.ts
+++ b/src/style/foundation/color/semanticColor/semanticColorPalette.ts
@@ -70,6 +70,7 @@ export const semanticColorPalette: SemanticColorPalette = {
   iconBasicSecondary: primitiveColorPalette.gray700,
   iconBasicTertiary: primitiveColorPalette.gray500,
   iconBasicDisabled: primitiveColorPalette.gray200,
+  iconBasicDisabledStrong: primitiveColorPalette.gray300,
   iconBasicWhite: primitiveColorPalette.neutralWhite,
 
   iconBrandPrimary: primitiveColorPalette.violet500,


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #154 

### 기존 코드에 영향을 미치지 않는 변경사항

- `iconBasicDisabledStrong` 토큰을 추가했습니다

- `Boxbutton` `TextButton` 내부 svg의 컬러를 `fill`로 제어하도록 수정했습니다

  기존에는 텍스트 컬러 지정을 위해 넣은 `color` 속성이 svg에도 적용되고 있었는데요

  이는 text semantic color를 아이콘에도 사용하는 거랑 같아서.... `fill`로 svg 색상을 명시했습니다

- `Boxbutton` `TextButton` 문서에 `leftIcon`(`rightIcon`) 관련 내용을 추가했습니다

  ![image](https://github.com/user-attachments/assets/d4c50314-2c87-4ea8-9641-c056e11255af)
  
  ![image](https://github.com/user-attachments/assets/a353946a-0a67-4b1b-a2d6-bce236c7414b)

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
