### PR TITLE
feat: snackbar semantic color 토큰(info, error) 추가

### DIFF
--- a/src/style/foundation/color/semanticColor/semanticColor.type.ts
+++ b/src/style/foundation/color/semanticColor/semanticColor.type.ts
@@ -102,6 +102,8 @@ export type SemanticPaginationBasicColor = MergeVariants<'pagination', 'basic', 
 
 export type SemanticSwitchColor = MergeVariants<'switch', SelectableVariantWithDisabled | 'thumb'>;
 
+export type SemanticSnackbarColor = MergeVariants<'snackbar', 'info' | 'error'>;
+
 export type SemanticColorType =
   | SemanticBackgroundBasicColor
   | SemanticBackgroundBrandColor
@@ -126,6 +128,7 @@ export type SemanticColorType =
   | SemanticChipColor
   | SemanticPaginationBrandColor
   | SemanticPaginationBasicColor
-  | SemanticSwitchColor;
+  | SemanticSwitchColor
+  | SemanticSnackbarColor;
 
 export type SemanticColorPalette = Readonly<Record<SemanticColorType, string>>;

--- a/src/style/foundation/color/semanticColor/semanticColorPalette.ts
+++ b/src/style/foundation/color/semanticColor/semanticColorPalette.ts
@@ -93,4 +93,7 @@ export const semanticColorPalette: SemanticColorPalette = {
   switchUnselected: primitiveColorPalette.gray300,
   switchDisabled: primitiveColorPalette.gray200,
   switchThumb: primitiveColorPalette.neutralWhite,
+
+  snackbarInfo: primitiveColorPalette.gray800,
+  snackbarError: primitiveColorPalette.statusRedSub,
 } as const;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
snackbar semantic color 토큰(info, error)을 추가하였습니다.

- resolved #163 

어푸룹 Plz!

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
