### PR TITLE
config: modify github workflow for Handy distribution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,17 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install
@@ -33,7 +34,7 @@ jobs:
 
       - name: Extract version from package.json
         id: version
-        run: echo ::set-output name=VERSION::$(node -p "require('./package.json').version")
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Deploy to s3
         env:
@@ -44,7 +45,7 @@ jobs:
             --recursive \
             --region ap-northeast-2 \
             ./storybook-static \
-            s3://yds-react-storybook/${{ steps.version.outputs.VERSION }}
+            s3://handy-react-storybook/${{ steps.version.outputs.VERSION }}
 
       - name: Publish to NPM
         run: npm publish

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@yourssu/design-system-react",
+  "packageManager": "pnpm@9.15.2",
   "private": false,
   "version": "2.0.0",
   "description": "Yourssu Design System for React",
@@ -74,6 +75,5 @@
     "vite-tsconfig-paths": "^4.2.0",
     "webfontloader": "^1.6.28",
     "xmldom": "^0.6.0"
-  },
-  "packageManager": "pnpm@8.15.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yourssu/design-system-react",
   "private": false,
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Yourssu Design System for React",
   "keywords": [
     "yourssu",


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- Handy 배포를 위해 일부 파일을 수정했습니다

### 기존 코드에 영향을 미치지 않는 변경사항

- deploy.yml

  - 사용하는 액션의 버전을 최신 버전으로 수정했습니다
  - pnpm 메이저 버전을 9로 수정했습니다
  - AWS s3 버킷명을 수정했습니다 (해당 버킷은 제가 생성해뒀어요)

- package.json

  - 버전을 `2.0.0`으로 수정했습니다
  - `packageManger` 버전도 `9.15.2`로 수정했습니다 (따봉효민아 고마워~!)

### 버그 픽스

- deploy.yml에서 deprecated된 `set-output` 명령어를 삭제하고, 환경 파일을 사용하는 방식으로 대체했습니다

  - [GitHub Blog: GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

  ![image](https://github.com/user-attachments/assets/23355fe8-d8a5-47d9-a5c1-ac8e50e4d160)

## 2️⃣ 알아두시면 좋아요!

- deploy.yml의 동작 방식 및 package.json의 일부 필드 설명이 필요해 보여서 [노션](https://www.notion.so/yourssu/d829f0beeff947be9a91cf99dd9dceeb?pvs=4#1f4881b0af9540aabf37f18fc0df7787)에 적어뒀습니다

- 라이브러리명/버전 관리에 대해 의견 필요한 부분이 있어 추가 코멘트 달아두겠습니다

## 3️⃣ 추후 작업

- ~**해당 브랜치에서 README.md 수정까지 마친 후 머지 하겠습니다.**
  다만 리드미 형식을 다른 개발팀이랑 어떻게 맞출지는 안 정했던 거 같아서 채널에 질문 올려둘게요~

  - 리드미는 별도 PR로 수정하겠습니다 말바꿔서 지송 ! 

- 메이저 버전 1에 대한 deprecate 메시지 추가 (`npm deprecate`)

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
