### PR TITLE
fix: deploy.yml pnpm 버전 충돌 문제 해결

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,7 @@
 # 이 파일은 release note 작성에 사용되는 파일입니다.
 
 changelog:
-  name-template: '@Yourssu Design/design-system-react@$RESOLVED_VERSION'
+  name-template: '@yourssu/design-system-react@$RESOLVED_VERSION'
   tag-template: 'v$RESOLVED_VERSION'
   categories:
     - title: '🆕 Exciting New Features!'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

### 기존 코드에 영향을 미치지 않는 변경사항

- release.yml의 `name-template`를 package.json의 `name`과 동일하게 변경했습니다. 사진에 표시한 부분이에요

  ![image](https://github.com/user-attachments/assets/6a1c453c-08f4-4b9f-b63e-553b07e97a01)

### 버그 픽스

- pnpm 버전이 두 곳에 명시되어 있으면 안되네요 deploy.yml에선 지웠어요

  ![image](https://github.com/user-attachments/assets/e3f13257-6057-403a-b760-a67872963550)

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
