### PR TITLE
bug: color.stories.ts semanticColorCategories 수정 및 AllThemeColors 에러 해결 작업

### DIFF
--- a/src/style/foundation/color/color.mdx
+++ b/src/style/foundation/color/color.mdx
@@ -60,4 +60,12 @@ const StyledDiv = styled.div`
 
 <br />
 
-<ColorStories.AllThemeColors />
+<ColorStories.AllThemeColors>
+  {({ colors }) => (
+    <ColorPalette>
+      {colors.map((color) => (
+        <ColorItem title={color.title} subtitle="theme.semantic.color" colors={color.colors} />
+      ))}
+    </ColorPalette>
+  )}
+</ColorStories.AllThemeColors>

--- a/src/style/foundation/color/color.stories.tsx
+++ b/src/style/foundation/color/color.stories.tsx
@@ -60,7 +60,7 @@ const AllThemeColors = ({ children }: AllThemeColorsProps) => {
     chip: ['chip'],
     pagination: ['paginationBrand', 'paginationBasic'],
     switch: ['switch'],
-    Snackbar: ['snackbar'],
+    snackbar: ['snackbar'],
   };
 
   return (

--- a/src/style/foundation/color/color.stories.tsx
+++ b/src/style/foundation/color/color.stories.tsx
@@ -42,8 +42,8 @@ const AllThemeColors = () => {
   const semanticColorCategories = {
     background: ['bgBasic', 'bgBrand', 'bgStatus'],
     text: ['textBasic', 'textBrand', 'textStatus'],
-    line: ['lineBasic', 'lineStatus'],
-    'button/box': ['buttonBoxPrimary', 'buttonBoxSecondary', 'buttonBoxTertiary'],
+    line: ['lineBasic', 'lineBrand', 'lineStatus'],
+    'button/box': ['buttonFilledPrimary', 'buttonFilledSecondary', 'buttonOutlined'],
     'button/text': ['buttonTextPrimary', 'buttonTextSecondary'],
     'button/fab': ['buttonFabPrimary', 'buttonFabSecondary'],
     'button/radio': ['buttonRadio'],
@@ -51,6 +51,8 @@ const AllThemeColors = () => {
     checkbox: ['checkbox'],
     chip: ['chip'],
     pagination: ['paginationBrand', 'paginationBasic'],
+    switch: ['switch'],
+    Snackbar: ['snackbar'],
   };
 
   return (

--- a/src/style/foundation/color/color.stories.tsx
+++ b/src/style/foundation/color/color.stories.tsx
@@ -1,8 +1,16 @@
-import { ColorItem, ColorPalette } from '@storybook/blocks';
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { styled } from 'styled-components';
 
 import { semanticColorPalette } from '@/style/foundation/color/semanticColor';
+
+type SemanticColorPalette = {
+  title: string;
+  colors: Record<string, string>;
+};
+
+interface AllThemeColorsProps {
+  children?: ({ colors }: { colors: SemanticColorPalette[] }) => React.ReactElement;
+}
 
 const meta: Meta = {
   title: 'Foundation/Color',
@@ -19,7 +27,7 @@ const StyledColorExample = styled.div`
   background-color: ${({ theme }) => theme.semantic.color.bgBrandPrimary};
 `;
 
-const AllThemeColors = () => {
+const AllThemeColors = ({ children }: AllThemeColorsProps) => {
   const getSemanticColorPalette = (prefix: string) => {
     const colors: Record<string, string> = {};
 
@@ -65,17 +73,7 @@ const AllThemeColors = () => {
         return (
           <div>
             <h2>{section}</h2>
-            <ColorPalette>
-              {colors.map((color) => {
-                return (
-                  <ColorItem
-                    title={color.title}
-                    subtitle="theme.semantic.color"
-                    colors={color.colors}
-                  />
-                );
-              })}
-            </ColorPalette>
+            {children && children({ colors })}
             <br />
             <br />
           </div>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #175 

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

- Chaeri 작업 내용

semanticColorCategories에 있는 애들이 semanticColorPalette에 존재하지 않아 getSemanticColorPalette에서 색상을 찾을 수 없어 나타난 오류였습니다. semanticColorPalette와 semanticColorCategories를 맞춰주었어요!

- Feca 작업 내용

`AllThemeColors` 컴포넌트에서 문서 전용 컴포넌트인 `ColorPalette`, `ColorItem` 을 렌더링하고 있었어요.
따라서 `AllThemeColors` 의 스토리에서 해당 컴포넌트들을 렌더링할 수 없는 문제가 있었던 거고요.

그래서 기존 `AllThemeColors` 에서 가져오던 시맨틱 컬러셋들을 render props 패턴으로 사용처로 렌더링 작업을 위임하고,
문서를 렌더링하는 사용처에서 `ColorPalette`, `ColorItem` 을 사용해서 렌더링 작업을 해주도록 변경했어요.

살짝 아쉬운거는 `AllThemeColors` 스토리가 이렇게 보인다는 점...? 근데 애초에 이게 정상 작동이니 큰 문제는 없을듯해요

<img width="1820" alt="스크린샷 2025-01-24 20 06 25" src="https://github.com/user-attachments/assets/74f4468f-d9f0-4f17-bbb9-c598802025ce" />


### 버그 픽스

## 2️⃣ 알아두시면 좋아요!

- https://github.com/storybookjs/storybook/issues/8753

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
