### PR TITLE
fix: `react/jsx-runtime`을 번들링하지 않도록 하여 `react@19` 호환성 개선

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,15 +23,15 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'styled-components', '**/*.stories.tsx'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'styled-components',
+        '**/*.stories.tsx',
+      ],
       output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          'styled-components': 'styled',
-        },
         banner: '"use client";',
-        interop: 'compat',
       },
     },
     ssr: false,


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- `react/jsx-runtime`을 번들링하지 않도록 하여 `react@19`(및 가까운 미래 버전)에서 라이브러리가 동작하도록 하였습니다.
- 추가로 불필요한 UMD variable 제거했습니다.
- 번들링 사이즈가 줄어 성능 개선 효과도 있을 것으로 예상

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

### 버그 픽스

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [X] `main` 브랜치의 최신 코드를 `pull` 받았나요?
