### PR TITLE
fix: 페이지네이션 컴포넌트의 totalPages에 1도 허용해요

### DIFF
--- a/src/components/Pagination/Pagination.mdx
+++ b/src/components/Pagination/Pagination.mdx
@@ -46,7 +46,7 @@ const onPageChange = (page: number) => { ... };
 
 ### totalPage
 
-전체 페이지 수를 의미하는 프로퍼티입니다. 2 미만의 값을 넣을 경우 에러가 발생합니다.<br />
+전체 페이지 수를 의미하는 프로퍼티입니다. 1 미만의 값을 넣을 경우 에러가 발생합니다.<br />
 `totalPage <= 5`일 때, 이전/다음 버튼은 생성되지 않습니다.
 
 <Canvas of={PaginationStories.TotalPage} />

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -6,7 +6,7 @@ import { StyledButton, StyledNav } from './Pagination.style';
 import { PaginationProps } from './Pagination.type';
 
 export const Pagination = ({ totalPage, initialPage = 1, onPageChange }: PaginationProps) => {
-  if (totalPage <= 1) throw new Error('totalPage는 2 이상의 숫자여야 합니다.');
+  if (totalPage <= 0) throw new Error('totalPage는 1 이상의 숫자여야 합니다.');
   if (initialPage > totalPage) throw new Error('initialPage는 totalPage보다 클 수 없습니다.');
 
   const [currentPage, setCurrentPage] = useState(initialPage);


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

### 버그 픽스

totalPages 값이 2 이상만 가능했는데, 1도 허용하도록 변경해요.

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
